### PR TITLE
fix(core): preserve typed tool inputs through the executor

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -1336,6 +1336,17 @@ class _StrictTypedDictBaseModel(_TypedDictBaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+def is_typeddict_model(value: Any) -> bool:
+    """Return True when value is a Pydantic model synthesized from a TypedDict.
+
+    A parameter annotated as a TypedDict (or list[TypedDict]) is wrapped in a
+    Pydantic model for validation, but the tool function still expects a plain
+    dict. The executor uses this to re-emit such arguments as dicts while leaving
+    genuine BaseModel arguments as model instances.
+    """
+    return isinstance(value, _TypedDictBaseModel)
+
+
 def create_model_from_typeddict(
     typeddict_class: type, model_name: str, strict: bool = False
 ) -> type[BaseModel]:

--- a/libs/arcade-core/arcade_core/executor.py
+++ b/libs/arcade-core/arcade_core/executor.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
+from arcade_core.catalog import is_typeddict_model
 from arcade_core.errors import (
     ToolInputError,
     ToolOutputError,
@@ -49,7 +50,7 @@ class ToolExecutor:
             inputs = await ToolExecutor._serialize_input(input_model, **kwargs)
 
             # prepare the arguments for the function call
-            func_args = inputs.model_dump()
+            func_args = _build_func_args(inputs)
 
             # inject ToolContext, if the target function supports it
             if definition.input.tool_context_parameter_name is not None:
@@ -143,3 +144,24 @@ class ToolExecutor:
             ) from e
 
         return output
+
+
+def _build_func_args(inputs: BaseModel) -> dict[str, Any]:
+    """Map the validated input model to keyword arguments for the tool function.
+
+    Each argument reaches the tool as the Python type it declared: a parameter
+    annotated as a BaseModel arrives as a model instance (so attribute access
+    works), while a parameter annotated as a TypedDict arrives as a plain dict
+    (so subscript access works). Dumping the whole model would collapse nested
+    models to dicts and break attribute access; keeping every field as-is would
+    hand TypedDict params a wrapper model they cannot subscript.
+    """
+    return {name: _to_func_arg(getattr(inputs, name)) for name in type(inputs).model_fields}
+
+
+def _to_func_arg(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_to_func_arg(item) for item in value]
+    if is_typeddict_model(value):
+        return value.model_dump()
+    return value

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.11.0"
+version = "4.11.1"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/tests/core/test_executor.py
+++ b/libs/tests/core/test_executor.py
@@ -16,6 +16,7 @@ from arcade_tdk.errors import (
     RetryableToolError,
     ToolExecutionError,
 )
+from pydantic import BaseModel
 from typing_extensions import TypedDict
 
 
@@ -380,6 +381,92 @@ def multi_field_tool(
 
 
 catalog.add_tool(multi_field_tool, "MultiFieldToolkit")
+
+
+# ---- Typed-object inputs ----
+# The executor must hand a tool its arguments as the Python types it declared:
+# a BaseModel param as a model instance (attribute access), and a TypedDict param
+# as a plain dict (subscript access).
+
+
+class NestedAddress(BaseModel):
+    city: Annotated[str, "city"]
+
+
+class NestedPerson(BaseModel):
+    name: Annotated[str, "name"]
+    address: Annotated[NestedAddress, "nested address"]
+
+
+class LineItem(BaseModel):
+    label: Annotated[str, "label"]
+    qty: Annotated[int, "quantity"]
+
+
+class FsNodeDict(TypedDict):
+    name: str
+    size: int
+
+
+@tool
+def greet_person(
+    person: Annotated[NestedPerson, "a person with a nested address"],
+) -> Annotated[str, "greeting"]:
+    """Reach into a nested BaseModel via attribute access."""
+    return f"{person.name} from {person.address.city}"
+
+
+@tool
+def total_quantity(items: Annotated[list[LineItem], "items to total"]) -> Annotated[int, "total"]:
+    """Reach into a list of BaseModels via attribute access."""
+    return sum(item.qty for item in items)
+
+
+@tool
+def describe_fs_node(
+    node: Annotated[FsNodeDict, "a filesystem node (TypedDict)"],
+) -> Annotated[str, "description"]:
+    """Reach into a TypedDict via subscript access."""
+    return f"{node['name']}:{node['size']}"
+
+
+for _typed_input_tool in (greet_person, total_quantity, describe_fs_node):
+    catalog.add_tool(_typed_input_tool, "TypedInputToolkit")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "tool_func, inputs, expected_value",
+    [
+        (
+            greet_person,
+            {"person": {"name": "Alice", "address": {"city": "NYC"}}},
+            "Alice from NYC",
+        ),
+        (
+            total_quantity,
+            {"items": [{"label": "a", "qty": 2}, {"label": "b", "qty": 3}]},
+            5,
+        ),
+        (describe_fs_node, {"node": {"name": "root", "size": 10}}, "root:10"),
+    ],
+    ids=["nested_basemodel", "list_of_basemodel", "typeddict_dict_access"],
+)
+async def test_executor_preserves_declared_input_types(tool_func, inputs, expected_value):
+    tool_definition = catalog.find_tool_by_func(tool_func)
+    full_tool = catalog.get_tool(tool_definition.get_fully_qualified_name())
+
+    output = await ToolExecutor.run(
+        func=tool_func,
+        definition=tool_definition,
+        input_model=full_tool.input_model,
+        output_model=full_tool.output_model,
+        context=ToolContext(),
+        **inputs,
+    )
+
+    assert output.error is None, output.error
+    assert output.value == expected_value
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Any tool whose input parameter is a Pydantic `BaseModel` (or `list[BaseModel]`) fails at execution with:

```
FatalToolError: An unhandled AttributeError was raised by the tool
  AttributeError: 'dict' object has no attribute '...'
```

## Root cause

`ToolExecutor.run` built the tool's call arguments with `inputs.model_dump()`:

```python
func_args = inputs.model_dump()   # recursively converts nested models to dicts
...
results = await func(**func_args)
```

`model_dump()` recursively converts every nested `BaseModel` to a plain `dict`. So a parameter declared as `person: Person` reaches the tool body as a `dict`, and `person.contact.address.city` raises `AttributeError`. The catalog builds the input model with the real annotated types (`create_func_models`), validation produces proper instances, and then `model_dump()` throws that structure away right before the call.

## Fix

Build the call arguments per field from the validated model, preserving Python-typed objects:

- **`BaseModel` params** are passed as model instances, so attribute access works.
- **`TypedDict` params** are re-emitted as plain dicts. The catalog wraps a `TypedDict` param in a Pydantic model for validation (`_wrap_typeddicts_as_models`, so `extra='forbid'` applies), but the tool body indexes it as a dict (`node["name"]`). A naive "keep everything as-is" fix would hand these tools the wrapper model and break subscripting, so a new `is_typeddict_model` predicate re-dumps exactly those (and lists of them).
- Scalars, `list[...]`, and `dict` params are unchanged.

## Tests

`libs/tests/core/test_executor.py` gains three cases through the full `ToolExecutor.run` path:

- nested `BaseModel` param (attribute access) — failed before, passes now
- `list[BaseModel]` param (attribute access on elements) — failed before, passes now
- `TypedDict` param (subscript access) — passed before and still passes (regression guard)

## Verification

- `libs/tests/core/` full suite: 442 passed
- `ruff check` / `ruff format --check` on changed source: clean
- `mypy` (lib-level, `--exclude tests`): no issues in 33 files

arcade-core bumped `4.9.0` → `4.9.1`. No public API change; behavior fix only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core executor argument shaping for every tool with structured inputs; fixes a widespread runtime bug but alters how `BaseModel` params reach tool code (from dicts to instances).
> 
> **Overview**
> **Tool execution** no longer passes validated inputs to tool functions via `inputs.model_dump()`. Instead, `ToolExecutor` builds kwargs per field so declared types survive the call boundary.
> 
> **`BaseModel` and `list[BaseModel]` parameters** stay as Pydantic instances (nested attribute access works). **`TypedDict` parameters** are still validated through strict wrapper models but are re-emitted as plain dicts via new `is_typeddict_model` and recursive `_to_func_arg` handling.
> 
> **Tests** cover nested `BaseModel`, `list[BaseModel]`, and `TypedDict` inputs through full `ToolExecutor.run`. **arcade-core** is patched **4.9.0 → 4.9.1** (behavior fix, no public API change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50f430bf517f27db676bc0d2e9de9d17eb3eaa5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->