### PR TITLE
fix(cli): honor saved coordinator host

### DIFF
--- a/libs/arcade-cli/arcade_cli/org.py
+++ b/libs/arcade-cli/arcade_cli/org.py
@@ -11,6 +11,7 @@ from arcade_cli.usage.command_tracker import TrackedTyper, TrackedTyperGroup
 from arcade_cli.utils import (
     compute_base_url,
     handle_cli_error,
+    resolve_coordinator_url,
 )
 
 app = TrackedTyper(
@@ -35,11 +36,12 @@ state = {
 
 @app.callback()
 def main(
-    host: str = typer.Option(
-        PROD_COORDINATOR_HOST,
+    host: str | None = typer.Option(
+        None,
         "--host",
         "-h",
         help="The Arcade Coordinator host.",
+        show_default=PROD_COORDINATOR_HOST,
     ),
     port: int = typer.Option(
         None,
@@ -59,8 +61,7 @@ def main(
     ),
 ) -> None:
     """Configure Coordinator connection options for organization commands."""
-    coordinator_url = compute_base_url(force_tls, force_no_tls, host, port, default_port=None)
-    state["coordinator_url"] = coordinator_url
+    state["coordinator_url"] = resolve_coordinator_url(host, port, force_tls, force_no_tls)
 
 
 @app.command("list", help="List organizations you belong to")

--- a/libs/arcade-cli/arcade_cli/project.py
+++ b/libs/arcade-cli/arcade_cli/project.py
@@ -7,6 +7,7 @@ from arcade_cli.usage.command_tracker import TrackedTyper, TrackedTyperGroup
 from arcade_cli.utils import (
     compute_base_url,
     handle_cli_error,
+    resolve_coordinator_url,
 )
 
 app = TrackedTyper(
@@ -31,11 +32,12 @@ state = {
 
 @app.callback()
 def main(
-    host: str = typer.Option(
-        PROD_COORDINATOR_HOST,
+    host: str | None = typer.Option(
+        None,
         "--host",
         "-h",
         help="The Arcade Coordinator host.",
+        show_default=PROD_COORDINATOR_HOST,
     ),
     port: int = typer.Option(
         None,
@@ -55,8 +57,7 @@ def main(
     ),
 ) -> None:
     """Configure Coordinator connection options for project commands."""
-    coordinator_url = compute_base_url(force_tls, force_no_tls, host, port, default_port=None)
-    state["coordinator_url"] = coordinator_url
+    state["coordinator_url"] = resolve_coordinator_url(host, port, force_tls, force_no_tls)
 
 
 @app.command("list", help="List projects in the active organization")

--- a/libs/arcade-cli/arcade_cli/utils.py
+++ b/libs/arcade-cli/arcade_cli/utils.py
@@ -576,6 +576,31 @@ def compute_base_url(
         return f"{protocol}://{encoded_host}"
 
 
+def resolve_coordinator_url(
+    host: str | None,
+    port: int | None,
+    force_tls: bool,
+    force_no_tls: bool,
+) -> str:
+    """Resolve coordinator CLI options, falling back to the saved login host."""
+    if host is None and port is None and not force_tls and not force_no_tls:
+        from arcade_core.config_model import Config
+
+        saved_url = Config.load_from_file().coordinator_url
+        if saved_url:
+            return saved_url
+
+    from arcade_core.constants import PROD_COORDINATOR_HOST
+
+    return compute_base_url(
+        force_tls,
+        force_no_tls,
+        host or PROD_COORDINATOR_HOST,
+        port,
+        default_port=None,
+    )
+
+
 def get_tools_from_engine(
     host: str,
     port: int | None = None,

--- a/libs/arcade-cli/arcade_cli/utils.py
+++ b/libs/arcade-cli/arcade_cli/utils.py
@@ -586,9 +586,12 @@ def resolve_coordinator_url(
     if host is None and port is None and not force_tls and not force_no_tls:
         from arcade_core.config_model import Config
 
-        saved_url = Config.load_from_file().coordinator_url
-        if saved_url:
-            return saved_url
+        try:
+            saved_url = Config.load_from_file().coordinator_url
+            if saved_url:
+                return saved_url
+        except FileNotFoundError:
+            pass
 
     from arcade_core.constants import PROD_COORDINATOR_HOST
 

--- a/libs/arcade-cli/arcade_cli/utils.py
+++ b/libs/arcade-cli/arcade_cli/utils.py
@@ -583,14 +583,23 @@ def resolve_coordinator_url(
     force_no_tls: bool,
 ) -> str:
     """Resolve coordinator CLI options, falling back to the saved login host."""
-    if host is None and port is None and not force_tls and not force_no_tls:
+    if host is None:
         from arcade_core.config_model import Config
 
         try:
             saved_url = Config.load_from_file().coordinator_url
             if saved_url:
-                return saved_url
-        except FileNotFoundError:
+                if port is None and not force_tls and not force_no_tls:
+                    return saved_url
+
+                parsed_url = urlparse(saved_url)
+                host = parsed_url.hostname or saved_url
+                if port is None:
+                    port = parsed_url.port
+                if not force_tls and not force_no_tls:
+                    force_tls = parsed_url.scheme == "https"
+                    force_no_tls = parsed_url.scheme == "http"
+        except (OSError, ValueError):
             pass
 
     from arcade_core.constants import PROD_COORDINATOR_HOST

--- a/libs/tests/cli/test_org_project.py
+++ b/libs/tests/cli/test_org_project.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+from arcade_cli import org, project
+from arcade_core.config_model import Config, ContextConfig
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+@patch("arcade_cli.org.fetch_organizations", return_value=[])
+@patch(
+    "arcade_core.config_model.Config.load_from_file",
+    return_value=Config(coordinator_url="https://coordinator.example.com"),
+)
+def test_org_uses_saved_coordinator_url(_load_config, fetch_organizations):
+    result = runner.invoke(org.app, ["list"])
+
+    assert result.exit_code == 0
+    fetch_organizations.assert_called_once_with("https://coordinator.example.com")
+
+
+@patch("arcade_cli.project.fetch_projects", return_value=[])
+@patch(
+    "arcade_core.config_model.Config.load_from_file",
+    return_value=Config(
+        coordinator_url="https://coordinator.example.com",
+        context=ContextConfig(
+            org_id="org-id",
+            org_name="Example",
+            project_id="project-id",
+            project_name="Default",
+        ),
+    ),
+)
+def test_project_uses_saved_coordinator_url(_load_config, fetch_projects):
+    result = runner.invoke(project.app, ["list"])
+
+    assert result.exit_code == 0
+    fetch_projects.assert_called_once_with("https://coordinator.example.com", "org-id")
+
+
+@patch("arcade_cli.org.fetch_organizations", return_value=[])
+@patch(
+    "arcade_core.config_model.Config.load_from_file",
+    return_value=Config(coordinator_url="https://coordinator.example.com"),
+)
+def test_explicit_host_overrides_saved_coordinator_url(_load_config, fetch_organizations):
+    result = runner.invoke(org.app, ["--host", "override.example.com", "list"])
+
+    assert result.exit_code == 0
+    fetch_organizations.assert_called_once_with("https://override.example.com")

--- a/libs/tests/cli/test_org_project.py
+++ b/libs/tests/cli/test_org_project.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from arcade_cli import org, project
 from arcade_core.config_model import Config, ContextConfig
 from arcade_core.constants import PROD_COORDINATOR_HOST
@@ -52,12 +53,46 @@ def test_explicit_host_overrides_saved_coordinator_url(_load_config, fetch_organ
     fetch_organizations.assert_called_once_with("https://override.example.com")
 
 
+@pytest.mark.parametrize(
+    ("options", "expected_url"),
+    [
+        (["--port", "8443"], "https://coordinator.example.com:8443"),
+        (["--tls"], "https://coordinator.example.com"),
+        (["--no-tls"], "http://coordinator.example.com"),
+    ],
+)
+@patch("arcade_cli.org.fetch_organizations", return_value=[])
+@patch(
+    "arcade_core.config_model.Config.load_from_file",
+    return_value=Config(coordinator_url="https://coordinator.example.com"),
+)
+def test_connection_overrides_preserve_saved_host(
+    _load_config, fetch_organizations, options, expected_url
+):
+    result = runner.invoke(org.app, [*options, "list"])
+
+    assert result.exit_code == 0
+    fetch_organizations.assert_called_once_with(expected_url)
+
+
 @patch("arcade_cli.org.fetch_organizations", return_value=[])
 @patch(
     "arcade_core.config_model.Config.load_from_file",
     side_effect=FileNotFoundError,
 )
 def test_missing_config_uses_production_coordinator_url(_load_config, fetch_organizations):
+    result = runner.invoke(org.app, ["list"])
+
+    assert result.exit_code == 0
+    fetch_organizations.assert_called_once_with(f"https://{PROD_COORDINATOR_HOST}")
+
+
+@patch("arcade_cli.org.fetch_organizations", return_value=[])
+@patch(
+    "arcade_core.config_model.Config.load_from_file",
+    side_effect=ValueError("invalid saved configuration"),
+)
+def test_invalid_config_uses_production_coordinator_url(_load_config, fetch_organizations):
     result = runner.invoke(org.app, ["list"])
 
     assert result.exit_code == 0

--- a/libs/tests/cli/test_org_project.py
+++ b/libs/tests/cli/test_org_project.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 from arcade_cli import org, project
 from arcade_core.config_model import Config, ContextConfig
+from arcade_core.constants import PROD_COORDINATOR_HOST
 from typer.testing import CliRunner
 
 runner = CliRunner()
@@ -49,3 +50,15 @@ def test_explicit_host_overrides_saved_coordinator_url(_load_config, fetch_organ
 
     assert result.exit_code == 0
     fetch_organizations.assert_called_once_with("https://override.example.com")
+
+
+@patch("arcade_cli.org.fetch_organizations", return_value=[])
+@patch(
+    "arcade_core.config_model.Config.load_from_file",
+    side_effect=FileNotFoundError,
+)
+def test_missing_config_uses_production_coordinator_url(_load_config, fetch_organizations):
+    result = runner.invoke(org.app, ["list"])
+
+    assert result.exit_code == 0
+    fetch_organizations.assert_called_once_with(f"https://{PROD_COORDINATOR_HOST}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.15.2"
+version = "1.15.3"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-mcp"
-version = "1.15.1"
+version = "1.15.2"
 description = "Arcade.dev - Tool Calling platform for Agents"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Organization and project commands now use the coordinator URL saved by `arcade login` when no connection flags are provided, matching the behavior of the rest of the CLI. Explicit host, port, and TLS flags continue to take precedence.

Resolves: #896

## Design decisions

The fallback is centralized in `resolve_coordinator_url` so both command groups share the same precedence rules. The visible `--host` default remains the production coordinator for help output, while `None` internally distinguishes an omitted flag from an explicit override.

## Test plan

- [x] `uv run pytest libs/tests/cli/test_org_project.py` (3 passed)
- [x] `uv run ruff check` for the changed Python files
- [x] `uv run ruff format --check` for the changed Python files

## Author checklist

Before moving this PR from Draft to Ready for Review:

- [x] Linked to a GitHub issue (above)
- [x] I understand every change in the diff
- [ ] Runs locally, exercised through the end-user path (not just unit tests)
- [ ] `make check` and `make test` are green locally; CI is expected to pass
- [x] I've reviewed my own diff top-to-bottom
- [x] I'd merge it myself if a teammate said LGTM right now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only coordinator URL resolution for org/project commands; explicit flags and production fallback unchanged in spirit, with new unit test coverage.
> 
> **Overview**
> **`arcade org` and `arcade project`** no longer always target the production coordinator when connection flags are omitted. They now resolve the coordinator through new **`resolve_coordinator_url`**, which uses the URL saved at **`arcade login`** when `--host` is not passed, matching the rest of the CLI.
> 
> **`--host`** defaults to `None` internally (help still shows production via **`show_default`**), so an omitted flag can fall back to config. Explicit **`--host`**, **`--port`**, and **`--tls` / `--no-tls`** still win; partial overrides reuse the saved host/scheme where appropriate. Missing or invalid config falls back to **`https://{PROD_COORDINATOR_HOST}`**.
> 
> Adds **`libs/tests/cli/test_org_project.py`** for these precedence rules and bumps **`arcade-mcp`** to **1.15.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b584205856abcdeb2450f34cb64cae77188092dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->