### PR TITLE
fix(arcade-tdk): make GraphQL adapter loader version-tolerant across gql 3.5.x/4.0.x (TOO-1338)

### DIFF
--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.25.1"
+version = "1.25.2"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -23,7 +23,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arcade-core>=4.11.0,<5.0.0",
     "arcade-serve>=3.4.0,<4.0.0",
-    "arcade-tdk>=3.10.0,<4.0.0",
+    "arcade-tdk>=3.10.1,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",
     "fastapi>=0.100.0",

--- a/libs/arcade-tdk/arcade_tdk/providers/graphql/error_adapter.py
+++ b/libs/arcade-tdk/arcade_tdk/providers/graphql/error_adapter.py
@@ -29,11 +29,32 @@ _GQL_CODE_TO_STATUS = {
 }
 
 
+class _MissingGqlError(Exception):
+    """Sentinel for a gql exception class absent on the installed gql version.
+
+    Substituted for a class the installed gql does not define so the adapter's
+    ``isinstance()`` checks stay valid but simply never match. Never raised or
+    instantiated.
+    """
+
+
 @lru_cache(maxsize=1)
 def _load_gql_transport_errors() -> (
     tuple[type[Any], type[Any], type[Any], type[Any], type[Any]] | None
 ):
-    """Import gql transport exceptions lazily and cache the result."""
+    """Import gql transport exceptions lazily and cache the result.
+
+    Each class is resolved with ``getattr`` and a never-raised sentinel so a gql
+    version that omits one of these names degrades gracefully instead of raising
+    ``AttributeError``. In particular ``TransportConnectionFailed`` was added in
+    gql 4.0.0 and does NOT exist on the stable 3.5.x line (the gql stable line
+    jumps 3.5.3 -> 4.0.0); consumers pinned to ``gql>=3.5,<4.0`` resolve to 3.5.3.
+    Eagerly reading ``module.TransportConnectionFailed`` there raised
+    ``AttributeError`` — which is not an ``ImportError``, so it escaped the guard,
+    was swallowed by the adapter chain in ``tool.py``, and silently disabled the
+    whole GraphQL adapter (TOO-1338). Resolving with ``getattr`` keeps every class
+    the installed gql *does* define working.
+    """
     try:
         module = importlib.import_module("gql.transport.exceptions")
     except ImportError:
@@ -41,11 +62,11 @@ def _load_gql_transport_errors() -> (
         return None
     else:
         return (
-            module.TransportError,
-            module.TransportQueryError,
-            module.TransportServerError,
-            module.TransportConnectionFailed,
-            module.TransportProtocolError,
+            getattr(module, "TransportError", _MissingGqlError),
+            getattr(module, "TransportQueryError", _MissingGqlError),
+            getattr(module, "TransportServerError", _MissingGqlError),
+            getattr(module, "TransportConnectionFailed", _MissingGqlError),
+            getattr(module, "TransportProtocolError", _MissingGqlError),
         )
 
 
@@ -113,7 +134,7 @@ class GraphQLErrorAdapter(BaseHTTPErrorMapper):
 
         # Extract error codes and map to HTTP status
         codes: list[str] = []
-        status = HTTPStatus.UNPROCESSABLE_ENTITY.value
+        mapped_statuses: list[int] = []
 
         for e in errors_list:
             ext = e.get("extensions") if isinstance(e, dict) else None
@@ -121,8 +142,19 @@ class GraphQLErrorAdapter(BaseHTTPErrorMapper):
             if isinstance(code, str):
                 codes.append(code)
                 mapped = _GQL_CODE_TO_STATUS.get(code)
-                if mapped and mapped > status:
-                    status = mapped
+                if mapped is not None:
+                    mapped_statuses.append(mapped)
+
+        # 422 (Unprocessable Entity) is only a fallback for when no recognized
+        # GraphQL error code was present. When codes DID map, pick the highest
+        # mapped status so a 5xx (retryable) wins over a 4xx in a multi-error
+        # response. The previous code seeded `status` at 422 and only replaced it
+        # when `mapped > status`, so specific 4xx codes below the 422 floor —
+        # NOT_FOUND (404), FORBIDDEN (403), UNAUTHENTICATED (401), BAD_USER_INPUT
+        # (400) — never won and were reported as 422 (TOO-1338, secondary bug).
+        status = (
+            max(mapped_statuses) if mapped_statuses else HTTPStatus.UNPROCESSABLE_ENTITY.value
+        )
 
         unique_codes = sorted(set(codes))
 

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "3.10.0"
+version = "3.10.1"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/tests/sdk/test_graphql_adapter.py
+++ b/libs/tests/sdk/test_graphql_adapter.py
@@ -294,3 +294,183 @@ class TestGraphQLErrorAdapter:
         """Should handle empty/None messages."""
         assert gql_adapter._extract_error_message(None) == "Unknown GraphQL error"
         assert gql_adapter._extract_error_message("") == "Unknown GraphQL error"
+
+    # --- Status-code selection (secondary bug: TOO-1338) ---
+
+    def test_query_error_single_not_found_maps_to_404(self) -> None:
+        """A lone NOT_FOUND must win over the 422 default, not be masked by it."""
+        exc = DummyTransportQueryError(
+            errors=[{"message": "Entity not found", "extensions": {"code": "NOT_FOUND"}}]
+        )
+
+        with _patch_loader():
+            result = gql_adapter.GraphQLErrorAdapter().from_exception(exc)
+
+        assert isinstance(result, UpstreamError)
+        assert result.status_code == HTTPStatus.NOT_FOUND
+        assert "Entity not found" in result.message
+
+    @pytest.mark.parametrize(
+        ("code", "expected"),
+        [
+            ("UNAUTHENTICATED", HTTPStatus.UNAUTHORIZED),
+            ("FORBIDDEN", HTTPStatus.FORBIDDEN),
+            ("NOT_FOUND", HTTPStatus.NOT_FOUND),
+            ("BAD_USER_INPUT", HTTPStatus.BAD_REQUEST),
+        ],
+    )
+    def test_query_error_specific_4xx_codes_are_not_masked_by_422(
+        self, code: str, expected: HTTPStatus
+    ) -> None:
+        """Every mapped 4xx code below the 422 floor must be reported as itself."""
+        exc = DummyTransportQueryError(errors=[{"message": "boom", "extensions": {"code": code}}])
+
+        with _patch_loader():
+            result = gql_adapter.GraphQLErrorAdapter().from_exception(exc)
+
+        assert isinstance(result, UpstreamError)
+        assert result.status_code == expected
+
+    def test_query_error_unknown_code_still_defaults_to_422(self) -> None:
+        """An unrecognized code carries no mapped status → 422 fallback stands."""
+        exc = DummyTransportQueryError(
+            errors=[{"message": "weird", "extensions": {"code": "SOMETHING_ELSE"}}]
+        )
+
+        with _patch_loader():
+            result = gql_adapter.GraphQLErrorAdapter().from_exception(exc)
+
+        assert isinstance(result, UpstreamError)
+        assert result.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+        assert result.extra["gql_error_codes"] == ["SOMETHING_ELSE"]
+
+
+# --- Regression: graceful degradation across gql versions (TOO-1338) ---
+#
+# gql is not a test dependency, so these tests do not import a real gql. Instead
+# they build a fake ``gql.transport.exceptions`` module holding only the
+# exception classes a given gql version defines, and drive the *real* loader
+# through it. This covers both the stable 3.5.x profile (no
+# TransportConnectionFailed) and the 4.0.x profile (all present) deterministically
+# and without installing multiple gql builds.
+
+
+class _FakeTransportError(Exception):
+    def __init__(self, message: str = "", code: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class _FakeTransportQueryError(_FakeTransportError):
+    def __init__(self, errors: list[dict[str, Any]] | None = None) -> None:
+        super().__init__("query error")
+        self.errors = errors
+
+
+class _FakeTransportServerError(_FakeTransportError):
+    pass
+
+
+class _FakeTransportProtocolError(_FakeTransportError):
+    pass
+
+
+class _FakeTransportConnectionFailed(_FakeTransportError):
+    pass
+
+
+# Mirrors gql's real inventory per version. 3.5.x has no TransportConnectionFailed;
+# 4.0.x adds it. Both keep TransportProtocolError (present on both lines).
+_GQL_VERSION_PROFILES = {
+    "3.5.x": {
+        "TransportError": _FakeTransportError,
+        "TransportQueryError": _FakeTransportQueryError,
+        "TransportServerError": _FakeTransportServerError,
+        "TransportProtocolError": _FakeTransportProtocolError,
+    },
+    "4.0.x": {
+        "TransportError": _FakeTransportError,
+        "TransportQueryError": _FakeTransportQueryError,
+        "TransportServerError": _FakeTransportServerError,
+        "TransportProtocolError": _FakeTransportProtocolError,
+        "TransportConnectionFailed": _FakeTransportConnectionFailed,
+    },
+}
+
+
+def _install_fake_gql(monkeypatch: pytest.MonkeyPatch, profile: str) -> None:
+    """Point the real loader at a fake gql module for the given version profile."""
+    from types import ModuleType
+
+    fake_module = ModuleType("gql.transport.exceptions")
+    for name, cls in _GQL_VERSION_PROFILES[profile].items():
+        setattr(fake_module, name, cls)
+
+    def fake_import(name: str) -> ModuleType:
+        assert name == "gql.transport.exceptions"
+        return fake_module
+
+    monkeypatch.setattr(gql_adapter.importlib, "import_module", fake_import)
+    gql_adapter._load_gql_transport_errors.cache_clear()
+
+
+@pytest.mark.parametrize("profile", ["3.5.x", "4.0.x"])
+def test_loader_degrades_when_transport_class_missing(
+    monkeypatch: pytest.MonkeyPatch, profile: str
+) -> None:
+    """The loader must never raise AttributeError, even when a class is absent."""
+    _install_fake_gql(monkeypatch, profile)
+
+    types_tuple = gql_adapter._load_gql_transport_errors()
+
+    assert types_tuple is not None
+    assert len(types_tuple) == 5
+    # TransportConnectionFailed (index 3) is the sentinel on 3.5.x, real on 4.0.x.
+    if profile == "3.5.x":
+        assert types_tuple[3] is gql_adapter._MissingGqlError
+    else:
+        assert types_tuple[3] is _FakeTransportConnectionFailed
+
+
+@pytest.mark.parametrize("profile", ["3.5.x", "4.0.x"])
+def test_query_error_maps_to_upstream_even_when_class_missing(
+    monkeypatch: pytest.MonkeyPatch, profile: str
+) -> None:
+    """The core TOO-1338 regression: a TransportQueryError must map to an
+    UpstreamError carrying the real message on gql 3.5.x, where
+    TransportConnectionFailed is missing — not fall through to FatalToolError."""
+    _install_fake_gql(monkeypatch, profile)
+
+    exc = _FakeTransportQueryError(
+        errors=[{"message": "Entity not found", "extensions": {"code": "NOT_FOUND"}}]
+    )
+    result = gql_adapter.GraphQLErrorAdapter().from_exception(exc)
+
+    assert isinstance(result, UpstreamError)
+    assert result.status_code == HTTPStatus.NOT_FOUND
+    assert result.message == "Upstream GraphQL error: Entity not found"
+
+
+def test_protocol_error_still_maps_on_35x_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The sentinel substituted for the missing TransportConnectionFailed must not
+    swallow TransportProtocolError, which DOES exist on 3.5.x."""
+    _install_fake_gql(monkeypatch, "3.5.x")
+
+    result = gql_adapter.GraphQLErrorAdapter().from_exception(
+        _FakeTransportProtocolError("Invalid response")
+    )
+
+    assert isinstance(result, NetworkTransportError)
+    assert result.kind == ErrorKind.NETWORK_TRANSPORT_RUNTIME_UNREACHABLE
+
+
+def test_missing_sentinel_never_matches_real_exceptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On 3.5.x a connection-style error unknown to the adapter must fall through
+    (return None), NOT be misclassified by the sentinel standing in for the
+    missing TransportConnectionFailed."""
+    _install_fake_gql(monkeypatch, "3.5.x")
+
+    # An arbitrary non-gql exception is not a TransportError subclass here.
+    result = gql_adapter.GraphQLErrorAdapter().from_exception(RuntimeError("unrelated"))
+
+    assert result is None


### PR DESCRIPTION
## TOO-1338 — Linear toolkit masks GraphQL errors as generic FatalToolError

Root-caused to **this** repo's GraphQL error adapter, not the downstream toolkit.

### The bug
`_load_gql_transport_errors()` (`libs/arcade-tdk/arcade_tdk/providers/graphql/error_adapter.py`) eagerly read `module.TransportConnectionFailed`, guarded **only** by `except ImportError`.

`TransportConnectionFailed` was added in **gql 4.0.0** and does **not** exist on the stable **3.5.x** line (the gql stable line jumps `3.5.3 -> 4.0.0`; no stable 3.6.x was ever released). Any consumer pinned to `gql>=3.5,<4.0` resolves to **3.5.3**, where that attribute access raises `AttributeError` — which is *not* an `ImportError`, so it escaped the guard.

Downstream, `_raise_as_arcade_error` in `tool.py` iterates the adapter chain inside a broad `except Exception` that logs and `continue`s. So the GraphQL adapter was **silently skipped**, the HTTP fallback didn't recognize a gql `TransportQueryError`, and the call fell through to `FatalToolError: An unhandled TransportQueryError was raised by the tool.` The real GraphQL `errors[]` message ("Entity not found" / "not authorized") was dropped from the agent-facing `message` (surviving only in `developer_message` / logs).

**Reproduced empirically** on real gql 3.5.3 (raised `AttributeError`) and confirmed fixed on both 3.5.3 and 4.0.0 (now → `UpstreamError`, status 404, message `Upstream GraphQL error: Entity not found`).

### The fix
Resolve each gql exception class with `getattr(module, name, _MissingGqlError)`, where `_MissingGqlError` is a private, never-raised sentinel. The adapter's `isinstance()` checks stay valid but simply never match a class the installed gql doesn't define — and every class a partial version *does* define still maps correctly (verified: `TransportProtocolError` still works on 3.5.x).

### Secondary bug (fixed in this PR)
`_handle_query_error` seeded `status` at the 422 floor and only replaced it when `mapped > status`, so specific 4xx codes below 422 — **NOT_FOUND (404), FORBIDDEN (403), UNAUTHENTICATED (401), BAD_USER_INPUT (400)** — never won and were reported as 422. Now 422 is only the fallback when *no* recognized code is present; when codes map, the **highest mapped status wins**. This preserves the existing "5xx wins over 4xx in a multi-error response" contract (existing test: FORBIDDEN + INTERNAL_SERVER_ERROR → 500) while fixing lone-4xx masking. Fixed here because it's a one-block change in the same function on the same error path.

### Supported gql-version policy (decision)
arcade-tdk supports **gql 3.5.x AND 4.0.x**. gql is an optional/soft dependency (toolkits bring their own; it is *not* an arcade-tdk or test dependency). Rather than add a heavyweight multi-install CI matrix, regression coverage is **version-agnostic**: tests build a fake `gql.transport.exceptions` module holding exactly the class inventory of each version profile (3.5.x omits `TransportConnectionFailed`; 4.0.x includes it) and drive the real loader through it. This is deterministic, needs no gql install, and covers both lines. gql 4.0's other additions (`TransportConnectionClosed`/`TransportClosed`, `TransportAlreadyConnected`) are **not** referenced by the adapter, so nothing else is version-fragile.

### Tests
- Loader degrades (no `AttributeError`) on both profiles; sentinel occupies the missing slot on 3.5.x.
- Core regression: `TransportQueryError` → `UpstreamError` with the real message even when `TransportConnectionFailed` is absent.
- `TransportProtocolError` still maps on the 3.5.x profile (sentinel doesn't swallow it).
- 4xx status-selection: lone NOT_FOUND → 404; FORBIDDEN/UNAUTHENTICATED/NOT_FOUND/BAD_USER_INPUT each reported as themselves; unknown code still → 422.
- Full `libs/tests/sdk` + `libs/tests/tool` suites green (736 passed).

## Rollout — versions consumers must bump to
Downstream toolkits depend on the **published** packages, so the fix reaches them only after release. Bump minimums to:

- **arcade-tdk `>=3.10.1`** (bumped 3.10.0 → 3.10.1) — required for anyone depending on arcade-tdk directly.
- **arcade-mcp-server `>=1.25.2`** (bumped 1.25.1 → 1.25.2; its arcade-tdk floor raised to `>=3.10.1`) — required for anyone getting arcade-tdk transitively via arcade-mcp-server, so a fresh resolve is forced onto the fixed arcade-tdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)