### PR TITLE
feat(arcade-mcp-server): add optional context parameter to prompt handlers

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/managers/prompt.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/managers/prompt.py
@@ -6,14 +6,45 @@ Async-safe prompts with registry-based storage and deterministic listing.
 
 from __future__ import annotations
 
+import inspect
 import logging
-from typing import Callable
+from typing import TYPE_CHECKING, Callable, Union
 
 from arcade_mcp_server.exceptions import NotFoundError, PromptError
 from arcade_mcp_server.managers.base import ComponentManager
 from arcade_mcp_server.types import GetPromptResult, Prompt, PromptMessage
 
+if TYPE_CHECKING:
+    from arcade_mcp_server.context import Context
+
 logger = logging.getLogger("arcade.mcp.managers.prompt")
+
+# Prompt handlers come in two flavors:
+# - legacy: (args) -> list[PromptMessage]
+# - context-aware: (context, args) -> list[PromptMessage], matching tool handlers
+PromptHandlerFunc = Union[
+    Callable[[dict[str, str]], "list[PromptMessage]"],
+    Callable[["Context | None", dict[str, str]], "list[PromptMessage]"],
+]
+
+
+def _handler_accepts_context(handler: Callable) -> bool:
+    """Whether a handler uses the context-aware (context, args) signature.
+
+    Handlers with two or more explicit positional parameters are treated as
+    context-aware. Handlers whose signature cannot be inspected, or that only
+    accept *args, are treated as legacy (args-only).
+    """
+    try:
+        sig = inspect.signature(handler)
+    except (TypeError, ValueError):
+        return False
+    positional = [
+        p
+        for p in sig.parameters.values()
+        if p.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    return len(positional) >= 2
 
 
 class PromptHandler:
@@ -22,10 +53,11 @@ class PromptHandler:
     def __init__(
         self,
         prompt: Prompt,
-        handler: Callable[[dict[str, str]], list[PromptMessage]] | None = None,
+        handler: PromptHandlerFunc | None = None,
     ) -> None:
         self.prompt = prompt
         self.handler = handler or self._default_handler
+        self._accepts_context = handler is not None and _handler_accepts_context(handler)
 
     def __eq__(self, other: object) -> bool:  # pragma: no cover - simple comparison
         if not isinstance(other, PromptHandler):
@@ -43,7 +75,11 @@ class PromptHandler:
             )
         ]
 
-    async def get_messages(self, arguments: dict[str, str] | None = None) -> list[PromptMessage]:
+    async def get_messages(
+        self,
+        arguments: dict[str, str] | None = None,
+        context: Context | None = None,
+    ) -> list[PromptMessage]:
         args = arguments or {}
 
         # Validate required arguments
@@ -52,7 +88,14 @@ class PromptHandler:
                 if arg.required and arg.name not in args:
                     raise PromptError(f"Required argument '{arg.name}' not provided")
 
-        result = self.handler(args)
+        if self._accepts_context:
+            if context is None:
+                from arcade_mcp_server.context import get_current_model_context
+
+                context = get_current_model_context()
+            result = self.handler(context, args)  # type: ignore[call-arg, arg-type]
+        else:
+            result = self.handler(args)  # type: ignore[call-arg, arg-type]
         if hasattr(result, "__await__"):
             result = await result
 
@@ -72,7 +115,10 @@ class PromptManager(ComponentManager[str, PromptHandler]):
         return [h.prompt for h in handlers]
 
     async def get_prompt(
-        self, name: str, arguments: dict[str, str] | None = None
+        self,
+        name: str,
+        arguments: dict[str, str] | None = None,
+        context: Context | None = None,
     ) -> GetPromptResult:
         try:
             handler = await self.registry.get(name)
@@ -80,7 +126,7 @@ class PromptManager(ComponentManager[str, PromptHandler]):
             raise NotFoundError(f"Prompt '{name}' not found")
 
         try:
-            messages = await handler.get_messages(arguments)
+            messages = await handler.get_messages(arguments, context)
             return GetPromptResult(
                 description=handler.prompt.description,
                 messages=messages,
@@ -93,7 +139,7 @@ class PromptManager(ComponentManager[str, PromptHandler]):
     async def add_prompt(
         self,
         prompt: Prompt,
-        handler: Callable[[dict[str, str]], list[PromptMessage]] | None = None,
+        handler: PromptHandlerFunc | None = None,
     ) -> None:
         prompt_handler = PromptHandler(prompt, handler)
         await self.registry.upsert(prompt.name, prompt_handler)
@@ -109,7 +155,7 @@ class PromptManager(ComponentManager[str, PromptHandler]):
         self,
         name: str,
         prompt: Prompt,
-        handler: Callable[[dict[str, str]], list[PromptMessage]] | None = None,
+        handler: PromptHandlerFunc | None = None,
     ) -> Prompt:
         # Ensure exists
         try:

--- a/libs/arcade-mcp-server/arcade_mcp_server/mcp_app.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/mcp_app.py
@@ -36,6 +36,7 @@ from arcade_mcp_server._validation import normalize_version
 from arcade_mcp_server.decorators import tool as tool_decorator
 from arcade_mcp_server.exceptions import ServerError
 from arcade_mcp_server.logging_utils import intercept_standard_logging
+from arcade_mcp_server.managers.prompt import PromptHandlerFunc
 from arcade_mcp_server.managers.resource import (
     _is_template_uri,
     make_file_handler,
@@ -47,7 +48,6 @@ from arcade_mcp_server.settings import MCPSettings, ServerSettings, find_env_fil
 from arcade_mcp_server.types import (
     Annotations,
     Prompt,
-    PromptMessage,
     Resource,
     ResourceTemplate,
     ToolExecution,
@@ -773,9 +773,7 @@ class _PromptsAPI:
     def __init__(self, app: MCPApp) -> None:
         self._app = app
 
-    async def add(
-        self, prompt: Prompt, handler: Callable[[dict[str, str]], list[PromptMessage]] | None = None
-    ) -> None:
+    async def add(self, prompt: Prompt, handler: PromptHandlerFunc | None = None) -> None:
         if self._app.server is None:
             raise ServerError("No server bound to app. Set app.server to use runtime prompts API.")
         await self._app.server.prompts.add_prompt(prompt, handler)

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -2172,6 +2172,7 @@ class MCPServer:
             result = await self._prompt_manager.get_prompt(
                 message.params.name,
                 message.params.arguments if hasattr(message.params, "arguments") else None,
+                context=get_current_model_context(),
             )
             return JSONRPCResponse(id=message.id, result=result)
         except NotFoundError:

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.25.2"
+version = "1.26.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/libs/tests/arcade_mcp_server/test_prompt.py
+++ b/libs/tests/arcade_mcp_server/test_prompt.py
@@ -1,8 +1,10 @@
 """Tests for Prompt Manager implementation."""
 
 import asyncio
+from unittest.mock import Mock
 
 import pytest
+from arcade_mcp_server.context import set_current_model_context
 from arcade_mcp_server.exceptions import NotFoundError, PromptError
 from arcade_mcp_server.managers.prompt import PromptManager
 from arcade_mcp_server.types import (
@@ -239,3 +241,140 @@ class TestPromptManager:
 
         with pytest.raises(PromptError):
             await manager.get_prompt("error_prompt", {})
+
+
+class TestPromptHandlerContext:
+    """Test context-aware prompt handlers (SDK parity with TypeScript)."""
+
+    @pytest.fixture
+    def prompt_manager(self):
+        return PromptManager()
+
+    @pytest.fixture
+    def sample_prompt(self):
+        return Prompt(
+            name="greeting",
+            description="A greeting prompt",
+            arguments=[PromptArgument(name="name", required=True)],
+        )
+
+    @pytest.mark.asyncio
+    async def test_context_style_handler_receives_explicit_context(
+        self, prompt_manager, sample_prompt
+    ):
+        """A (context, args) handler receives the context passed to get_prompt."""
+        received = {}
+
+        async def greeting(context, args: dict[str, str]) -> list[PromptMessage]:
+            received["context"] = context
+            return [
+                PromptMessage(
+                    role="user", content={"type": "text", "text": f"Hello {args['name']}"}
+                )
+            ]
+
+        await prompt_manager.add_prompt(sample_prompt, greeting)
+
+        fake_context = Mock()
+        result = await prompt_manager.get_prompt("greeting", {"name": "Ada"}, context=fake_context)
+
+        assert received["context"] is fake_context
+        assert result.messages[0].content["text"] == "Hello Ada"
+
+    @pytest.mark.asyncio
+    async def test_context_style_handler_falls_back_to_current_model_context(
+        self, prompt_manager, sample_prompt
+    ):
+        """Without an explicit context, the active request context is used."""
+        received = {}
+
+        async def greeting(context, args: dict[str, str]) -> list[PromptMessage]:
+            received["context"] = context
+            return [PromptMessage(role="user", content={"type": "text", "text": "hi"})]
+
+        await prompt_manager.add_prompt(sample_prompt, greeting)
+
+        fake_context = Mock()
+        token = set_current_model_context(fake_context)
+        try:
+            await prompt_manager.get_prompt("greeting", {"name": "Ada"})
+        finally:
+            set_current_model_context(None, token)
+
+        assert received["context"] is fake_context
+
+    @pytest.mark.asyncio
+    async def test_context_style_handler_receives_none_without_context(
+        self, prompt_manager, sample_prompt
+    ):
+        """With no context anywhere, a (context, args) handler receives None."""
+        received = {"context": "sentinel"}
+
+        async def greeting(context, args: dict[str, str]) -> list[PromptMessage]:
+            received["context"] = context
+            return [PromptMessage(role="user", content={"type": "text", "text": "hi"})]
+
+        await prompt_manager.add_prompt(sample_prompt, greeting)
+        await prompt_manager.get_prompt("greeting", {"name": "Ada"})
+
+        assert received["context"] is None
+
+    @pytest.mark.asyncio
+    async def test_legacy_handler_does_not_receive_context(self, prompt_manager, sample_prompt):
+        """A single-parameter (args) handler keeps working when a context is active."""
+
+        async def greeting(args: dict[str, str]) -> list[PromptMessage]:
+            return [
+                PromptMessage(
+                    role="user", content={"type": "text", "text": f"Hello {args['name']}"}
+                )
+            ]
+
+        await prompt_manager.add_prompt(sample_prompt, greeting)
+
+        token = set_current_model_context(Mock())
+        try:
+            result = await prompt_manager.get_prompt("greeting", {"name": "Ada"}, context=Mock())
+        finally:
+            set_current_model_context(None, token)
+
+        assert result.messages[0].content["text"] == "Hello Ada"
+
+    @pytest.mark.asyncio
+    async def test_sync_context_style_handler(self, prompt_manager, sample_prompt):
+        """Sync (context, args) handlers are supported."""
+        received = {}
+
+        def greeting(context, args: dict[str, str]) -> list[PromptMessage]:
+            received["context"] = context
+            return [PromptMessage(role="user", content={"type": "text", "text": "hi"})]
+
+        await prompt_manager.add_prompt(sample_prompt, greeting)
+
+        fake_context = Mock()
+        await prompt_manager.get_prompt("greeting", {"name": "Ada"}, context=fake_context)
+
+        assert received["context"] is fake_context
+
+    @pytest.mark.asyncio
+    async def test_var_positional_handler_treated_as_legacy(self, prompt_manager, sample_prompt):
+        """Handlers taking *args are treated as legacy (args-only) for safety."""
+        received = {}
+
+        async def greeting(*args) -> list[PromptMessage]:
+            received["args"] = args
+            return [PromptMessage(role="user", content={"type": "text", "text": "hi"})]
+
+        await prompt_manager.add_prompt(sample_prompt, greeting)
+        await prompt_manager.get_prompt("greeting", {"name": "Ada"}, context=Mock())
+
+        assert received["args"] == ({"name": "Ada"},)
+
+    @pytest.mark.asyncio
+    async def test_default_handler_still_works_with_context(self, prompt_manager, sample_prompt):
+        """The built-in default handler is unaffected by context passing."""
+        await prompt_manager.add_prompt(sample_prompt)
+
+        result = await prompt_manager.get_prompt("greeting", {"name": "Ada"}, context=Mock())
+
+        assert result.messages[0].content["text"] == "A greeting prompt"


### PR DESCRIPTION
## Summary

Implements #707 — prompt handlers can now receive the request `Context` as their first parameter, `(context, args)`, for parity with tool handlers and the TypeScript SDK.

```python
# New context-aware style
async def greeting(context: Context, args: dict[str, str]) -> list[PromptMessage]:
    await context.log.info("generating greeting")
    return [PromptMessage(role="user", content={"type": "text", "text": f"Hello {args['name']}"})]

# Legacy style — still works unchanged
async def greeting(args: dict[str, str]) -> list[PromptMessage]:
    ...
```

## How it works

- `PromptHandler` inspects the handler signature once at registration (as proposed in the issue): two or more explicit positional parameters → context-aware; one → legacy. Handlers that only take `*args`, or whose signature can't be inspected, are treated as legacy for safety.
- `PromptManager.get_prompt()` / `PromptHandler.get_messages()` accept an optional `context`. `_handle_get_prompt` in `server.py` passes the current request context explicitly; when not passed, the handler falls back to the active request context from the ContextVar, so context-aware handlers get a real `Context` in both stdio and HTTP modes.
- New `PromptHandlerFunc` union type used in the manager and `app.prompts.add()`.

## Backward compatibility

No breaking change — existing single-parameter handlers work exactly as before (all pre-existing prompt tests pass unmodified). Version bumped 1.25.2 → 1.26.0 (minor, new capability).

## Testing

- 7 new tests in `libs/tests/arcade_mcp_server/test_prompt.py` (TDD — written first, confirmed failing before implementation): explicit context passing, ContextVar fallback, `None` when no context is active, legacy handlers unaffected, sync context-aware handlers, `*args` treated as legacy, default handler unaffected.
- Full `libs/tests/arcade_mcp_server/` suite passes (1,413 tests); ruff and strict mypy clean on changed files.

Closes #707

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API with signature-based backward compatibility; request context wiring mirrors existing tool handling with no auth or data-model changes.
> 
> **Overview**
> Adds **context-aware prompt handlers** `(context, args)` alongside the existing `(args)` style, aligned with tool handlers and the TypeScript SDK.
> 
> At registration, `inspect.signature` decides the call shape: two or more explicit positional parameters get `Context` (from `get_prompt` or the request `ContextVar`); single-arg and `*args` handlers stay legacy. `prompts/get` now passes `get_current_model_context()` into the prompt manager. Public APIs use the new `PromptHandlerFunc` union; package version is **1.26.0** with dedicated tests for explicit context, ContextVar fallback, legacy compatibility, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10d4aced8f109954f003ebec04644d2b818e582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->