### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.2, release arcade-serve 3.4.2

### DIFF
--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -176,7 +176,7 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
       - name: Send status to Slack
         if: always()

--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -176,7 +176,7 @@ jobs:
           path: dist/
 
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@a892a5a61159132606e93a2fa6f4358831b04d26 # v1.14.2
 
       - name: Send status to Slack
         if: always()

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.4.1"
+version = "3.4.2"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## What broke

The `arcade-serve` 3.4.1 release never reached PyPI. The `pypi-publish` job in [run 31654382725](https://github.com/ArcadeAI/arcade-mcp/actions/runs/31654382725/job/94305781483) failed at the upload step:

```
Checking dist/arcade_serve-3.4.1-py3-none-any.whl: ERROR InvalidDistribution:
Invalid distribution metadata: '2.5' is not a valid metadata version
```

PyPI still shows 3.4.0 as latest. `detect-version-changes` and `build-and-test` both passed; only the publish step failed.

## Why

The publish step was pinned to `cef2210`, a `release/v1` commit from 2026-02-18 that bundles twine 6.1.0 / packaging 25.0. That packaging release only recognizes core metadata versions up to 2.4.

Meanwhile the build step runs `uv build`, which resolves the newest Hatchling at build time, and that now emits `Metadata-Version: 2.5`. Both the wheel and the sdist from the failing run carry 2.5. Nothing changed in the package itself; the build side moved forward and the pinned publisher did not.

## Verification

I downloaded the actual artifacts from the failing run and parsed them with both packaging versions:

- `packaging==25.0` (pinned action) rejects the wheel: `invalid or unparsed metadata`
- `packaging==26.2` (v1.14.2) parses it and reports `metadata_version = 2.5`

v1.14.2 bundles twine 7.0.0 / packaging 26.2.

## The changes

1. Bump the action pin to v1.14.2 (`a892a5a`), still SHA-pinned.
2. Bump `arcade-serve` to 3.4.2.

The version bump is here rather than in a follow-up PR because of how the release workflow triggers. It fires only on a push to `main`, and `check-version-changes.sh` looks for a changed `version = ` line in the `HEAD^..HEAD` diff of a package's `pyproject.toml`. A workflow-only fix would merge without releasing anything, and re-running the failed job would not help either, since a re-run uses the workflow file as of the original triggering commit and would pick up the old pin again.

Merging this PR pushes both changes to `main` in one commit. That push runs the workflow with the fixed pin and the changed version line, so 3.4.2 publishes on merge.

## Notes

- 3.4.2 contains no code changes over 3.4.1. 3.4.1 will simply never exist on PyPI.
- The downstream constraint in `arcade-mcp-server` (`arcade-serve>=3.4.0,<4.0.0`) still holds, so no dependent needs updating.
- This bug was never specific to `arcade-serve`. The next version bump of any package in the repo would have hit the same failure.
- Worth confirming on PyPI after merge that 3.4.2 actually lands.

Tracked in TOO-1850.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI dependency pin and a version-only release bump; no application or security logic changes.
> 
> **Overview**
> **Fixes failed PyPI uploads** by SHA-pinning `pypa/gh-action-pypi-publish` to **v1.14.2** in `release-on-version-change.yml`, replacing an older `release/v1` commit whose bundled twine/packaging rejected wheels built with **Metadata-Version 2.5**.
> 
> **Triggers a new release** by bumping `arcade-serve` from **3.4.1 → 3.4.2** in `libs/arcade-serve/pyproject.toml` so the version-change workflow runs on merge with the fixed publisher (3.4.1 never shipped; 3.4.2 is a republish with no package code changes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f889a500d750a61116751f74aaf330502bb9cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->