### PR TITLE
[PLT-2917] feat: expose toolkit trigger declarations

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -312,7 +312,10 @@ class ToolCatalog(BaseModel):
             return
 
         combined_trigger_types = [*self.trigger_types, *toolkit.trigger_types]
-        validate_trigger_types(combined_trigger_types)
+        try:
+            validate_trigger_types(combined_trigger_types)
+        except ValueError as e:
+            raise ToolkitLoadError(str(e)).with_context(toolkit.name) from e
 
         for module_name, tool_names in toolkit.tools.items():
             for tool_name in tool_names:

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -307,7 +307,7 @@ class ToolCatalog(BaseModel):
             description: Optionally override the description of the toolkit with this parameter
         """
 
-        if str(toolkit).lower() in self._disabled_toolkits:
+        if toolkit.name.lower() in self._disabled_toolkits:
             logger.info(f"Server '{toolkit.name!s}' is disabled and will not be cataloged.")
             return
 

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -53,6 +53,7 @@ from arcade_core.schema import (
     ValueSchema,
 )
 from arcade_core.toolkit import Toolkit
+from arcade_core.triggers import TriggerType, validate_trigger_types
 from arcade_core.utils import (
     does_function_return_value,
     first_or_none,
@@ -158,6 +159,8 @@ class ToolCatalog(BaseModel):
 
     _disabled_tools: set[str] = set()
     _disabled_toolkits: set[str] = set()
+
+    trigger_types: list[TriggerType] = Field(default_factory=list)
 
     def __init__(self, **data) -> None:  # type: ignore[no-untyped-def]
         super().__init__(**data)
@@ -308,6 +311,9 @@ class ToolCatalog(BaseModel):
             logger.info(f"Server '{toolkit.name!s}' is disabled and will not be cataloged.")
             return
 
+        combined_trigger_types = [*self.trigger_types, *toolkit.trigger_types]
+        validate_trigger_types(combined_trigger_types)
+
         for module_name, tool_names in toolkit.tools.items():
             for tool_name in tool_names:
                 try:
@@ -340,6 +346,8 @@ class ToolCatalog(BaseModel):
                     raise ToolDefinitionError(
                         f"Error encountered while adding tool {tool_name} from {module_name}. Reason: {e}"
                     ).with_context(tool_name)
+
+        self.trigger_types = combined_trigger_types
 
     def __getitem__(self, name: FullyQualifiedName) -> MaterializedTool:
         return self.get_tool(name)

--- a/libs/arcade-core/arcade_core/toolkit.py
+++ b/libs/arcade-core/arcade_core/toolkit.py
@@ -7,12 +7,14 @@ import sys
 import types
 from collections import defaultdict
 from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
 
 import toml
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from arcade_core.errors import ToolkitLoadError
 from arcade_core.parse import get_tools_from_file
+from arcade_core.triggers import TriggerType, validate_trigger_types
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +30,9 @@ class Toolkit(BaseModel):
 
     tools: dict[str, list[str]] = defaultdict(list)
     """Mapping of module names to tools"""
+
+    trigger_types: list[TriggerType] = Field(default_factory=list)
+    """Trigger types declared by the toolkit."""
 
     # Other python package metadata
     version: str
@@ -124,6 +129,7 @@ class Toolkit(BaseModel):
         )
 
         toolkit.tools = cls.tools_from_directory(package_dir, package_name)
+        toolkit.trigger_types = cls.trigger_types_from_directory(package_dir)
 
         return toolkit
 
@@ -166,8 +172,26 @@ class Toolkit(BaseModel):
         )
 
         toolkit.tools = cls.tools_from_directory(package_dir, package_name)
+        toolkit.trigger_types = cls.trigger_types_from_directory(package_dir)
 
         return toolkit
+
+    @staticmethod
+    def trigger_types_from_directory(package_dir: Path) -> list[TriggerType]:
+        """Load ``<toolkit>.trigger_types.trigger_types`` when it is declared."""
+        if not (package_dir / "trigger_types.py").is_file():
+            return []
+
+        module_name = f"{package_dir.name}.trigger_types"
+        try:
+            module = importlib.import_module(module_name)
+            raw_declarations: Any = module.trigger_types
+            declarations = [TriggerType.model_validate(item) for item in raw_declarations]
+            validate_trigger_types(declarations)
+        except Exception as e:
+            raise ToolkitLoadError(f"Failed to load trigger types from '{module_name}': {e}") from e
+        else:
+            return declarations
 
     @classmethod
     def from_entrypoint(cls, entry: importlib.metadata.EntryPoint) -> "Toolkit":

--- a/libs/arcade-core/arcade_core/toolkit.py
+++ b/libs/arcade-core/arcade_core/toolkit.py
@@ -177,7 +177,9 @@ class Toolkit(BaseModel):
         return toolkit
 
     @staticmethod
-    def trigger_types_from_directory(package_dir: Path, package_name: str | None = None) -> list[TriggerType]:
+    def trigger_types_from_directory(
+        package_dir: Path, package_name: str | None = None
+    ) -> list[TriggerType]:
         """Load ``<toolkit>.trigger_types.trigger_types`` when it is declared."""
         if not (package_dir / "trigger_types.py").is_file():
             return []

--- a/libs/arcade-core/arcade_core/toolkit.py
+++ b/libs/arcade-core/arcade_core/toolkit.py
@@ -129,7 +129,7 @@ class Toolkit(BaseModel):
         )
 
         toolkit.tools = cls.tools_from_directory(package_dir, package_name)
-        toolkit.trigger_types = cls.trigger_types_from_directory(package_dir)
+        toolkit.trigger_types = cls.trigger_types_from_directory(package_dir, package_name)
 
         return toolkit
 
@@ -172,17 +172,17 @@ class Toolkit(BaseModel):
         )
 
         toolkit.tools = cls.tools_from_directory(package_dir, package_name)
-        toolkit.trigger_types = cls.trigger_types_from_directory(package_dir)
+        toolkit.trigger_types = cls.trigger_types_from_directory(package_dir, package_name)
 
         return toolkit
 
     @staticmethod
-    def trigger_types_from_directory(package_dir: Path) -> list[TriggerType]:
+    def trigger_types_from_directory(package_dir: Path, package_name: str | None = None) -> list[TriggerType]:
         """Load ``<toolkit>.trigger_types.trigger_types`` when it is declared."""
         if not (package_dir / "trigger_types.py").is_file():
             return []
 
-        module_name = f"{package_dir.name}.trigger_types"
+        module_name = f"{package_name or package_dir.name}.trigger_types"
         try:
             module = importlib.import_module(module_name)
             raw_declarations: Any = module.trigger_types

--- a/libs/arcade-core/arcade_core/triggers.py
+++ b/libs/arcade-core/arcade_core/triggers.py
@@ -1,0 +1,56 @@
+"""Trigger-type declarations.
+
+Toolkits declare trigger types as data; the worker serves them to the engine
+alongside tool definitions. Validation is load-time: a broken declaration must
+fail toolkit load, never reach the wire.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+
+class TriggerType(BaseModel):
+    """A toolkit-declared trigger type."""
+
+    slug: str
+    """Toolkit-namespaced identifier, e.g. "slack.message.received"."""
+
+    name: str
+    """Human-readable name shown in catalogues."""
+
+    description: str
+    """What the trigger watches for."""
+
+    kind: Literal["webhook", "poll"]
+    """Transport kind: provider-pushed webhook or engine-driven poll."""
+
+    config_schema: dict[str, Any]
+    """JSON Schema that per-instance config is validated against."""
+
+    payload_schema: dict[str, Any]
+    """Schema of the normalized event delivered on fire."""
+
+    sample_payload: dict[str, Any]
+    """Example payload for test-trigger UX and catalogue previews."""
+
+    version: str
+    """Declaration version; rides the toolkit version axis."""
+
+    instructions: str | None = None
+    """Setup guidance shown in the dashboard."""
+
+    verification: dict[str, Any] | None = None
+    """Webhook-kind: named verification scheme and params executed at ingress."""
+
+    normalize_handler: str | None = None
+    """Webhook-kind: tool reference invoked to normalize raw provider events."""
+
+    poll_handler: str | None = None
+    """Poll-kind: tool reference invoked on the polling cadence."""
+
+    default_interval: int | None = None
+    """Poll-kind: default polling interval in seconds."""
+
+    dedupe: Literal["unique", "greatest", "last"] | None = None
+    """Poll-kind: watermark dedupe strategy."""

--- a/libs/arcade-core/arcade_core/triggers.py
+++ b/libs/arcade-core/arcade_core/triggers.py
@@ -7,7 +7,9 @@ fail toolkit load, never reach the wire.
 
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from jsonschema import exceptions as jsonschema_exceptions
+from jsonschema.validators import validator_for
+from pydantic import BaseModel, field_validator
 
 
 class TriggerType(BaseModel):
@@ -54,6 +56,16 @@ class TriggerType(BaseModel):
 
     dedupe: Literal["unique", "greatest", "last"] | None = None
     """Poll-kind: watermark dedupe strategy."""
+
+    @field_validator("config_schema")
+    @classmethod
+    def _config_schema_is_valid_json_schema(cls, value: dict[str, Any]) -> dict[str, Any]:
+        validator_class = validator_for(value)
+        try:
+            validator_class.check_schema(value)
+        except jsonschema_exceptions.SchemaError as e:
+            raise ValueError(f"not a valid JSON Schema: {e.message}") from e
+        return value
 
 
 def validate_trigger_types(trigger_types: list[TriggerType]) -> None:

--- a/libs/arcade-core/arcade_core/triggers.py
+++ b/libs/arcade-core/arcade_core/triggers.py
@@ -54,3 +54,15 @@ class TriggerType(BaseModel):
 
     dedupe: Literal["unique", "greatest", "last"] | None = None
     """Poll-kind: watermark dedupe strategy."""
+
+
+def validate_trigger_types(trigger_types: list[TriggerType]) -> None:
+    """Validate a toolkit's trigger-type declarations as a collection.
+
+    Raises ValueError naming the offending slug so toolkit load fails fast.
+    """
+    seen: set[str] = set()
+    for trigger_type in trigger_types:
+        if trigger_type.slug in seen:
+            raise ValueError(f"Duplicate trigger type slug: {trigger_type.slug}")
+        seen.add(trigger_type.slug)

--- a/libs/arcade-core/arcade_core/triggers.py
+++ b/libs/arcade-core/arcade_core/triggers.py
@@ -57,9 +57,9 @@ class TriggerType(BaseModel):
     dedupe: Literal["unique", "greatest", "last"] | None = None
     """Poll-kind: watermark dedupe strategy."""
 
-    @field_validator("config_schema")
+    @field_validator("config_schema", "payload_schema")
     @classmethod
-    def _config_schema_is_valid_json_schema(cls, value: dict[str, Any]) -> dict[str, Any]:
+    def _schema_is_valid_json_schema(cls, value: dict[str, Any]) -> dict[str, Any]:
         validator_class = validator_for(value)
         try:
             validator_class.check_schema(value)

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.11.0"
+version = "4.11.1"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "types-pytz==2024.2.0.20241003",
     "types-toml==0.10.8.20240310",
     "posthog>=6.7.6,<7.0.0",
+    "jsonschema>=4.26.0",
 ]
 
 [project.optional-dependencies]

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "types-pytz>=2024.1",
     "types-python-dateutil>=2.8.2",
     "types-PyYAML>=6.0.0",
+    "types-jsonschema>=4.26.0",
 ]
 
 [build-system]

--- a/libs/arcade-mcp-server/arcade_mcp_server/worker.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/worker.py
@@ -242,6 +242,7 @@ def create_arcade_mcp(
             otel_meter=otel_handler.get_meter(),
         )
         worker.catalog = catalog
+        worker.register_trigger_types(catalog.trigger_types)
         logger.info("Worker routes enabled at /worker/* (ARCADE_WORKER_SECRET is set)")
 
     class _MCPASGIProxy:

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.26.0"
+version = "1.26.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,8 +21,8 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.11.0,<5.0.0",
-    "arcade-serve>=3.4.0,<4.0.0",
+    "arcade-core>=4.11.1,<5.0.0",
+    "arcade-serve>=3.4.3,<4.0.0",
     "arcade-tdk>=3.10.1,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",

--- a/libs/arcade-serve/arcade_serve/core/base.py
+++ b/libs/arcade-serve/arcade_serve/core/base.py
@@ -1,8 +1,9 @@
 import logging
 import os
 import time
+from collections.abc import Callable
 from datetime import datetime
-from typing import Any, Callable, ClassVar
+from typing import Any, ClassVar
 
 from arcade_core.catalog import ToolCatalog, Toolkit
 from arcade_core.executor import ToolExecutor
@@ -12,14 +13,16 @@ from arcade_core.schema import (
     ToolCallResponse,
     ToolDefinition,
 )
+from arcade_core.triggers import TriggerType, validate_trigger_types
 from opentelemetry import trace
 from opentelemetry.metrics import Meter
 
-from arcade_serve.core.common import Router, Worker
+from arcade_serve.core.common import Router, TriggerTypesResponse, Worker
 from arcade_serve.core.components import (
     CallToolComponent,
     CatalogComponent,
     HealthCheckComponent,
+    TriggerTypesComponent,
     WorkerComponent,
 )
 
@@ -38,6 +41,7 @@ class BaseWorker(Worker):
         CatalogComponent,
         CallToolComponent,
         HealthCheckComponent,
+        TriggerTypesComponent,
     )
 
     def __init__(
@@ -51,6 +55,7 @@ class BaseWorker(Worker):
         If no secret is provided, the worker will use the ARCADE_WORKER_SECRET environment variable.
         """
         self.catalog = ToolCatalog()
+        self.trigger_types: list[TriggerType] = []
         self.disable_auth = disable_auth
         if disable_auth:
             logger.warning(
@@ -100,6 +105,20 @@ class BaseWorker(Worker):
         Register a toolkit to the catalog.
         """
         self.catalog.add_toolkit(toolkit)
+
+    def register_trigger_types(self, trigger_types: list[TriggerType]) -> None:
+        """
+        Register toolkit-declared trigger types, validating the combined set.
+        """
+        combined = [*self.trigger_types, *trigger_types]
+        validate_trigger_types(combined)
+        self.trigger_types = combined
+
+    def get_trigger_types(self) -> TriggerTypesResponse:
+        """
+        Get the trigger types declared by the worker's toolkits.
+        """
+        return TriggerTypesResponse(trigger_types=self.trigger_types)
 
     async def call_tool(self, tool_request: ToolCallRequest) -> ToolCallResponse:
         """

--- a/libs/arcade-serve/arcade_serve/core/base.py
+++ b/libs/arcade-serve/arcade_serve/core/base.py
@@ -102,9 +102,12 @@ class BaseWorker(Worker):
 
     def register_toolkit(self, toolkit: Toolkit) -> None:
         """
-        Register a toolkit to the catalog.
+        Register a toolkit's tools and trigger types.
         """
+        combined_trigger_types = [*self.trigger_types, *toolkit.trigger_types]
+        validate_trigger_types(combined_trigger_types)
         self.catalog.add_toolkit(toolkit)
+        self.trigger_types = combined_trigger_types
 
     def register_trigger_types(self, trigger_types: list[TriggerType]) -> None:
         """

--- a/libs/arcade-serve/arcade_serve/core/base.py
+++ b/libs/arcade-serve/arcade_serve/core/base.py
@@ -104,10 +104,8 @@ class BaseWorker(Worker):
         """
         Register a toolkit's tools and trigger types.
         """
-        combined_trigger_types = [*self.trigger_types, *toolkit.trigger_types]
-        validate_trigger_types(combined_trigger_types)
         self.catalog.add_toolkit(toolkit)
-        self.trigger_types = combined_trigger_types
+        self.trigger_types = list(self.catalog.trigger_types)
 
     def register_trigger_types(self, trigger_types: list[TriggerType]) -> None:
         """

--- a/libs/arcade-serve/arcade_serve/core/common.py
+++ b/libs/arcade-serve/arcade_serve/core/common.py
@@ -97,12 +97,14 @@ class Worker(ABC):
         """
         pass
 
-    @abstractmethod
     def get_trigger_types(self) -> TriggerTypesResponse:
         """
         Get the trigger types declared by the worker's toolkits.
+
+        Non-abstract so existing Worker implementations keep working:
+        a worker that declares no trigger types serves an empty envelope.
         """
-        pass
+        return TriggerTypesResponse(trigger_types=[])
 
 
 class WorkerComponent(ABC):

--- a/libs/arcade-serve/arcade_serve/core/common.py
+++ b/libs/arcade-serve/arcade_serve/core/common.py
@@ -1,13 +1,23 @@
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 from arcade_core.schema import ToolCallRequest, ToolCallResponse, ToolDefinition
+from arcade_core.triggers import TriggerType
 from pydantic import BaseModel
 
 CatalogResponse = list[ToolDefinition]
 HealthCheckResponse = dict[str, str]
 JSONResponse = dict[str, Any]
-ResponseData = CatalogResponse | ToolCallResponse | HealthCheckResponse
+
+
+class TriggerTypesResponse(BaseModel):
+    """Envelope for trigger-type declarations served to the engine."""
+
+    trigger_types: list[TriggerType]
+
+
+ResponseData = CatalogResponse | ToolCallResponse | HealthCheckResponse | TriggerTypesResponse
 
 
 class RequestData(BaseModel):
@@ -84,6 +94,13 @@ class Worker(ABC):
     def health_check(self) -> HealthCheckResponse:
         """
         Perform a health check of the worker
+        """
+        pass
+
+    @abstractmethod
+    def get_trigger_types(self) -> TriggerTypesResponse:
+        """
+        Get the trigger types declared by the worker's toolkits.
         """
         pass
 

--- a/libs/arcade-serve/arcade_serve/core/components.py
+++ b/libs/arcade-serve/arcade_serve/core/components.py
@@ -10,6 +10,7 @@ from arcade_serve.core.common import (
     HealthCheckResponse,
     RequestData,
     Router,
+    TriggerTypesResponse,
     WorkerComponent,
 )
 
@@ -75,6 +76,31 @@ class CallToolComponent(WorkerComponent):
                 for key, value in build_tool_error_span_attributes(response.output.error).items():
                     current_span.set_attribute(key, value)
             return response
+
+
+class TriggerTypesComponent(WorkerComponent):
+    def register(self, router: Router) -> None:
+        """
+        Register the trigger-types route with the router.
+        """
+        router.add_route(
+            "triggers",
+            self,
+            method="GET",
+            response_type=TriggerTypesResponse,
+            operation_id="get_trigger_types",
+            description="Get the trigger types declared by the worker's toolkits",
+            summary="Get the declared trigger types",
+            tags=["Arcade"],
+        )
+
+    async def __call__(self, request: RequestData) -> TriggerTypesResponse:
+        """
+        Handle the request to get the declared trigger types.
+        """
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span("TriggerTypes"):
+            return self.worker.get_trigger_types()
 
 
 class HealthCheckComponent(WorkerComponent):

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.9.0,<5.0.0",
+    "arcade-core>=4.10.0,<5.0.0",
     "fastapi>=0.115.3",
     "uvicorn>=0.30.0",
     "watchfiles>=1.0.5",

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.4.2"
+version = "3.4.3"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.10.0,<5.0.0",
+    "arcade-core>=4.11.1,<5.0.0",
     "fastapi>=0.115.3",
     "uvicorn>=0.30.0",
     "watchfiles>=1.0.5",

--- a/libs/tests/arcade_mcp_server/test_openapi_docs.py
+++ b/libs/tests/arcade_mcp_server/test_openapi_docs.py
@@ -2,9 +2,35 @@
 
 from arcade_core import ToolCatalog
 from arcade_core.toolkit import Toolkit
+from arcade_core.triggers import TriggerType
 from arcade_mcp_server.settings import MCPSettings
 from arcade_mcp_server.worker import create_arcade_mcp
 from fastapi.testclient import TestClient
+
+
+def test_integrated_worker_serves_catalog_trigger_types(monkeypatch):
+    monkeypatch.setenv("ARCADE_AUTH_DISABLED", "true")
+    monkeypatch.setenv("ARCADE_WORKER_SECRET", "test")
+    declaration = TriggerType(
+        slug="example.changed",
+        name="Example changed",
+        description="Fires when an example changes.",
+        kind="poll",
+        config_schema={"type": "object"},
+        payload_schema={"type": "object"},
+        sample_payload={"id": "123"},
+        version="1",
+        poll_handler="Example.Poll",
+        default_interval=60,
+        dedupe="unique",
+    )
+    catalog = ToolCatalog(trigger_types=[declaration])
+    app = create_arcade_mcp(catalog, mcp_settings=MCPSettings.from_env())
+
+    response = TestClient(app).get("/worker/triggers")
+
+    assert response.status_code == 200
+    assert response.json()["trigger_types"][0]["slug"] == "example.changed"
 
 
 def test_mcp_routes_in_openapi(monkeypatch):

--- a/libs/tests/core/test_catalog.py
+++ b/libs/tests/core/test_catalog.py
@@ -11,6 +11,7 @@ from arcade_core.errors import (
 )
 from arcade_core.schema import FullyQualifiedName, ToolContext
 from arcade_core.toolkit import Toolkit
+from arcade_core.triggers import TriggerType
 from arcade_tdk import tool
 from pydantic import Field
 
@@ -186,6 +187,34 @@ def test_add_tool_with_toolkit():
         catalog.get_tool(FullyQualifiedName("SampleTool", "SampleToolkit", None)).tool
         == sample_tool
     )
+
+
+def test_add_toolkit_collects_trigger_types():
+    declaration = TriggerType(
+        slug="sample.changed",
+        name="Sample changed",
+        description="Fires when a sample changes.",
+        kind="poll",
+        config_schema={"type": "object"},
+        payload_schema={"type": "object"},
+        sample_payload={"id": "123"},
+        version="1",
+        poll_handler="Sample.Poll",
+        default_interval=60,
+        dedupe="unique",
+    )
+    toolkit = Toolkit(
+        name="sample_toolkit",
+        description="A sample toolkit",
+        version="1.0.0",
+        package_name="sample_toolkit",
+        trigger_types=[declaration],
+    )
+    catalog = ToolCatalog()
+
+    catalog.add_toolkit(toolkit)
+
+    assert catalog.trigger_types == [declaration]
 
 
 @pytest.mark.parametrize(

--- a/libs/tests/core/test_catalog.py
+++ b/libs/tests/core/test_catalog.py
@@ -217,6 +217,40 @@ def test_add_toolkit_collects_trigger_types():
     assert catalog.trigger_types == [declaration]
 
 
+def test_add_toolkit_rejects_duplicate_trigger_slug_as_toolkit_load_error():
+    declaration = TriggerType(
+        slug="sample.changed",
+        name="Sample changed",
+        description="Fires when a sample changes.",
+        kind="poll",
+        config_schema={"type": "object"},
+        payload_schema={"type": "object"},
+        sample_payload={"id": "123"},
+        version="1",
+    )
+    catalog = ToolCatalog()
+    catalog.add_toolkit(
+        Toolkit(
+            name="first_toolkit",
+            description="A first toolkit",
+            version="1.0.0",
+            package_name="first_toolkit",
+            trigger_types=[declaration],
+        )
+    )
+
+    with pytest.raises(ToolkitLoadError, match=r"Duplicate trigger type slug: sample\.changed"):
+        catalog.add_toolkit(
+            Toolkit(
+                name="second_toolkit",
+                description="A second toolkit",
+                version="1.0.0",
+                package_name="second_toolkit",
+                trigger_types=[declaration],
+            )
+        )
+
+
 @pytest.mark.parametrize(
     "toolkit_version, expected_tool",
     [

--- a/libs/tests/core/test_catalog.py
+++ b/libs/tests/core/test_catalog.py
@@ -414,6 +414,16 @@ def test_add_tool_with_whitespace_disabled_tools(monkeypatch):
 def test_add_tool_with_disabled_toolkit(monkeypatch):
     monkeypatch.setenv("ARCADE_DISABLED_TOOLKITS", "SampleToolkitOne")
     catalog = ToolCatalog()
+    declaration = TriggerType(
+        slug="sample.changed",
+        name="Sample changed",
+        description="Fires when a sample changes.",
+        kind="poll",
+        config_schema={"type": "object"},
+        payload_schema={"type": "object"},
+        sample_payload={"id": "123"},
+        version="1",
+    )
 
     catalog.add_toolkit(
         Toolkit(
@@ -421,9 +431,11 @@ def test_add_tool_with_disabled_toolkit(monkeypatch):
             package_name="sample_toolkit_one",
             version="1.0.0",
             description="A sample toolkit",
+            trigger_types=[declaration],
         )
     )
     assert len(catalog._tools) == 0
+    assert catalog.trigger_types == []
 
 
 @pytest.mark.parametrize(

--- a/libs/tests/core/test_toolkit.py
+++ b/libs/tests/core/test_toolkit.py
@@ -69,6 +69,17 @@ class TestToolkit:
 
         assert Toolkit.trigger_types_from_directory(package_dir) == []
 
+    def test_trigger_module_uses_resolved_package_name(self, tmp_path, monkeypatch):
+        package_dir = tmp_path / "project_root"
+        package_dir.mkdir()
+        (package_dir / "trigger_types.py").touch()
+        module = MagicMock(trigger_types=[])
+        import_module = MagicMock(return_value=module)
+        monkeypatch.setattr("arcade_core.toolkit.importlib.import_module", import_module)
+
+        assert Toolkit.trigger_types_from_directory(package_dir, "actual_toolkit") == []
+        import_module.assert_called_once_with("actual_toolkit.trigger_types")
+
 
 class TestFromEntrypoint:
     """Test the from_entrypoint class method."""

--- a/libs/tests/core/test_toolkit.py
+++ b/libs/tests/core/test_toolkit.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from arcade_core.errors import ToolkitLoadError
 from arcade_core.toolkit import Toolkit, Validate
+from arcade_core.triggers import TriggerType
 
 
 class TestToolkit:
@@ -37,6 +38,36 @@ class TestToolkit:
         assert Toolkit._strip_arcade_prefix("myarcade_toolkit") == "myarcade_toolkit"
         assert Toolkit._strip_arcade_prefix("") == ""
         assert Toolkit._strip_arcade_prefix("arcade_") == ""
+
+    def test_loads_trigger_types_from_conventional_module(self, tmp_path, monkeypatch):
+        package_dir = tmp_path / "arcade_example"
+        package_dir.mkdir()
+        (package_dir / "trigger_types.py").touch()
+        declaration = TriggerType(
+            slug="example.changed",
+            name="Example changed",
+            description="Fires when an example changes.",
+            kind="poll",
+            config_schema={"type": "object"},
+            payload_schema={"type": "object"},
+            sample_payload={"id": "123"},
+            version="1",
+            poll_handler="Example.Poll",
+            default_interval=60,
+            dedupe="unique",
+        )
+        module = MagicMock(trigger_types=[declaration])
+        import_module = MagicMock(return_value=module)
+        monkeypatch.setattr("arcade_core.toolkit.importlib.import_module", import_module)
+
+        assert Toolkit.trigger_types_from_directory(package_dir) == [declaration]
+        import_module.assert_called_once_with("arcade_example.trigger_types")
+
+    def test_toolkit_without_trigger_module_has_no_trigger_types(self, tmp_path):
+        package_dir = tmp_path / "arcade_example"
+        package_dir.mkdir()
+
+        assert Toolkit.trigger_types_from_directory(package_dir) == []
 
 
 class TestFromEntrypoint:

--- a/libs/tests/core/test_triggers.py
+++ b/libs/tests/core/test_triggers.py
@@ -1,7 +1,7 @@
 """Trigger-type declaration model: load-time validation."""
 
 import pytest
-from arcade_core.triggers import TriggerType
+from arcade_core.triggers import TriggerType, validate_trigger_types
 from pydantic import ValidationError
 
 
@@ -32,3 +32,11 @@ def test_missing_config_schema_fails_validation_naming_the_field():
         TriggerType.model_validate(declaration)
 
     assert "config_schema" in str(exc_info.value)
+
+
+def test_duplicate_slug_within_a_toolkit_fails_validation_naming_the_slug():
+    first = TriggerType.model_validate(valid_webhook_declaration())
+    second = TriggerType.model_validate(valid_webhook_declaration())
+
+    with pytest.raises(ValueError, match=r"slack\.message\.received"):
+        validate_trigger_types([first, second])

--- a/libs/tests/core/test_triggers.py
+++ b/libs/tests/core/test_triggers.py
@@ -1,0 +1,34 @@
+"""Trigger-type declaration model: load-time validation."""
+
+import pytest
+from arcade_core.triggers import TriggerType
+from pydantic import ValidationError
+
+
+def valid_webhook_declaration() -> dict:
+    return {
+        "slug": "slack.message.received",
+        "name": "Message received",
+        "description": "Fires when a message arrives in a subscribed channel.",
+        "kind": "webhook",
+        "config_schema": {
+            "type": "object",
+            "properties": {"channel": {"type": "string"}},
+            "required": ["channel"],
+        },
+        "payload_schema": {"type": "object"},
+        "sample_payload": {"channel": "C123", "text": "hi"},
+        "version": "1",
+        "verification": {"scheme": "slack_v0"},
+        "normalize_handler": "Slack.NormalizeMessageEvent",
+    }
+
+
+def test_missing_config_schema_fails_validation_naming_the_field():
+    declaration = valid_webhook_declaration()
+    del declaration["config_schema"]
+
+    with pytest.raises(ValidationError) as exc_info:
+        TriggerType.model_validate(declaration)
+
+    assert "config_schema" in str(exc_info.value)

--- a/libs/tests/core/test_triggers.py
+++ b/libs/tests/core/test_triggers.py
@@ -34,6 +34,16 @@ def test_missing_config_schema_fails_validation_naming_the_field():
     assert "config_schema" in str(exc_info.value)
 
 
+def test_invalid_config_schema_fails_validation_naming_the_field():
+    declaration = valid_webhook_declaration()
+    declaration["config_schema"] = {"type": "not-a-real-type"}
+
+    with pytest.raises(ValidationError) as exc_info:
+        TriggerType.model_validate(declaration)
+
+    assert "config_schema" in str(exc_info.value)
+
+
 def test_duplicate_slug_within_a_toolkit_fails_validation_naming_the_slug():
     first = TriggerType.model_validate(valid_webhook_declaration())
     second = TriggerType.model_validate(valid_webhook_declaration())

--- a/libs/tests/core/test_triggers.py
+++ b/libs/tests/core/test_triggers.py
@@ -44,6 +44,16 @@ def test_invalid_config_schema_fails_validation_naming_the_field():
     assert "config_schema" in str(exc_info.value)
 
 
+def test_invalid_payload_schema_fails_validation_naming_the_field():
+    declaration = valid_webhook_declaration()
+    declaration["payload_schema"] = {"type": "not-a-real-type"}
+
+    with pytest.raises(ValidationError) as exc_info:
+        TriggerType.model_validate(declaration)
+
+    assert "payload_schema" in str(exc_info.value)
+
+
 def test_duplicate_slug_within_a_toolkit_fails_validation_naming_the_slug():
     first = TriggerType.model_validate(valid_webhook_declaration())
     second = TriggerType.model_validate(valid_webhook_declaration())

--- a/libs/tests/worker/test_worker_base.py
+++ b/libs/tests/worker/test_worker_base.py
@@ -340,7 +340,7 @@ def test_register_routes_registers_default_components(base_worker, mock_router):
     assert mock_router.add_route.call_count == len(BaseWorker.default_components)
 
     calls = mock_router.add_route.call_args_list
-    expected_paths = ["tools", "tools/invoke", "health"]
+    expected_paths = ["tools", "tools/invoke", "health", "triggers"]
     registered_paths = [
         call[0][0] for call in calls
     ]  # call[0] are positional args, call[0][0] is endpoint_path

--- a/libs/tests/worker/test_worker_triggers.py
+++ b/libs/tests/worker/test_worker_triggers.py
@@ -59,6 +59,17 @@ def client_no_auth(test_app, worker_no_auth):
     return TestClient(test_app)
 
 
+def test_unauthenticated_request_is_rejected():
+    app = FastAPI()
+    worker = FastAPIWorker(app=app, secret="test-secret")  # noqa: S106
+    worker.register_trigger_types([webhook_type()])
+    client = TestClient(app)
+
+    response = client.get("/worker/triggers", headers={"Authorization": "Bearer invalid-token"})
+
+    assert response.status_code == 401
+
+
 def test_no_declarations_yields_an_empty_envelope():
     app = FastAPI()
     FastAPIWorker(app=app, disable_auth=True)

--- a/libs/tests/worker/test_worker_triggers.py
+++ b/libs/tests/worker/test_worker_triggers.py
@@ -1,0 +1,82 @@
+"""GET /worker/triggers — trigger-type declarations served on the worker protocol."""
+
+import pytest
+from arcade_core.triggers import TriggerType
+from arcade_serve.fastapi.worker import FastAPIWorker
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def webhook_type() -> TriggerType:
+    return TriggerType(
+        slug="slack.message.received",
+        name="Message received",
+        description="Fires when a message arrives in a subscribed channel.",
+        kind="webhook",
+        config_schema={
+            "type": "object",
+            "properties": {"channel": {"type": "string"}},
+            "required": ["channel"],
+        },
+        payload_schema={"type": "object"},
+        sample_payload={"channel": "C123", "text": "hi"},
+        version="1",
+        verification={"scheme": "slack_v0"},
+        normalize_handler="Slack.NormalizeMessageEvent",
+    )
+
+
+def poll_type() -> TriggerType:
+    return TriggerType(
+        slug="gmail.message.received",
+        name="Email received",
+        description="Fires when a new email lands in the inbox.",
+        kind="poll",
+        config_schema={"type": "object"},
+        payload_schema={"type": "object"},
+        sample_payload={"message_id": "18c4f2", "history_id": "12345"},
+        version="1",
+        poll_handler="Gmail.PollHistory",
+        default_interval=60,
+        dedupe="greatest",
+    )
+
+
+@pytest.fixture
+def test_app():
+    return FastAPI()
+
+
+@pytest.fixture
+def worker_no_auth(test_app):
+    worker = FastAPIWorker(app=test_app, disable_auth=True)
+    worker.register_trigger_types([webhook_type(), poll_type()])
+    return worker
+
+
+@pytest.fixture
+def client_no_auth(test_app, worker_no_auth):
+    return TestClient(test_app)
+
+
+def test_declared_trigger_types_are_served_with_complete_fields(client_no_auth):
+    response = client_no_auth.get("/worker/triggers")
+
+    assert response.status_code == 200
+    served = {t["slug"]: t for t in response.json()["trigger_types"]}
+    assert set(served) == {"slack.message.received", "gmail.message.received"}
+
+    webhook = served["slack.message.received"]
+    assert webhook["kind"] == "webhook"
+    assert webhook["config_schema"]["required"] == ["channel"]
+    assert webhook["payload_schema"] == {"type": "object"}
+    assert webhook["sample_payload"] == {"channel": "C123", "text": "hi"}
+    assert webhook["version"] == "1"
+    assert webhook["verification"] == {"scheme": "slack_v0"}
+    assert webhook["normalize_handler"] == "Slack.NormalizeMessageEvent"
+
+    poll = served["gmail.message.received"]
+    assert poll["kind"] == "poll"
+    assert poll["poll_handler"] == "Gmail.PollHistory"
+    assert poll["default_interval"] == 60
+    assert poll["dedupe"] == "greatest"

--- a/libs/tests/worker/test_worker_triggers.py
+++ b/libs/tests/worker/test_worker_triggers.py
@@ -1,7 +1,14 @@
 """GET /worker/triggers — trigger-type declarations served on the worker protocol."""
 
 import pytest
+from arcade_core.schema import ToolCallRequest, ToolCallResponse
 from arcade_core.triggers import TriggerType
+from arcade_serve.core.common import (
+    CatalogResponse,
+    HealthCheckResponse,
+    TriggerTypesResponse,
+    Worker,
+)
 from arcade_serve.fastapi.worker import FastAPIWorker
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
@@ -57,6 +64,22 @@ def worker_no_auth(test_app):
 @pytest.fixture
 def client_no_auth(test_app, worker_no_auth):
     return TestClient(test_app)
+
+
+def test_worker_implementations_without_trigger_support_serve_an_empty_envelope():
+    class MinimalWorker(Worker):
+        def get_catalog(self) -> CatalogResponse:
+            return []
+
+        async def call_tool(self, request: ToolCallRequest) -> ToolCallResponse:
+            raise NotImplementedError
+
+        def health_check(self) -> HealthCheckResponse:
+            return {"status": "ok"}
+
+    worker = MinimalWorker()
+
+    assert worker.get_trigger_types() == TriggerTypesResponse(trigger_types=[])
 
 
 def test_unauthenticated_request_is_rejected():

--- a/libs/tests/worker/test_worker_triggers.py
+++ b/libs/tests/worker/test_worker_triggers.py
@@ -59,6 +59,17 @@ def client_no_auth(test_app, worker_no_auth):
     return TestClient(test_app)
 
 
+def test_no_declarations_yields_an_empty_envelope():
+    app = FastAPI()
+    FastAPIWorker(app=app, disable_auth=True)
+    client = TestClient(app)
+
+    response = client.get("/worker/triggers")
+
+    assert response.status_code == 200
+    assert response.json() == {"trigger_types": []}
+
+
 def test_declared_trigger_types_are_served_with_complete_fields(client_no_auth):
     response = client_no_auth.get("/worker/triggers")
 

--- a/libs/tests/worker/test_worker_triggers.py
+++ b/libs/tests/worker/test_worker_triggers.py
@@ -2,6 +2,7 @@
 
 import pytest
 from arcade_core.schema import ToolCallRequest, ToolCallResponse
+from arcade_core.toolkit import Toolkit
 from arcade_core.triggers import TriggerType
 from arcade_serve.core.common import (
     CatalogResponse,
@@ -102,6 +103,26 @@ def test_no_declarations_yields_an_empty_envelope():
 
     assert response.status_code == 200
     assert response.json() == {"trigger_types": []}
+
+
+def test_registering_a_toolkit_exposes_its_trigger_types():
+    app = FastAPI()
+    worker = FastAPIWorker(app=app, disable_auth=True)
+    toolkit = Toolkit(
+        name="gmail",
+        package_name="arcade_gmail",
+        version="1.0.0",
+        description="Gmail toolkit",
+        trigger_types=[poll_type()],
+    )
+
+    worker.register_toolkit(toolkit)
+
+    response = TestClient(app).get("/worker/triggers")
+    assert response.status_code == 200
+    assert [item["slug"] for item in response.json()["trigger_types"]] == [
+        "gmail.message.received"
+    ]
 
 
 def test_declared_trigger_types_are_served_with_complete_fields(client_no_auth):


### PR DESCRIPTION
## Summary
- add validated trigger declaration models to arcade-core
- serve declarations from the authenticated `GET /worker/triggers` endpoint
- discover `<toolkit>.trigger_types.trigger_types` automatically
- carry declarations through `ToolCatalog` into the integrated MCP worker
- preserve compatibility for toolkits and workers without trigger support

## Verification
- 150 focused core/catalog/worker tests pass
- Ruff passes on changed files
- MyPy passes on changed source files
- clean Python 3.10 wheel smoke test exposes `servicetitan.job.completed` through `/worker/triggers`

Tracks the SDK/worker portion of Arcade monorepo ticket J95ZCA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New worker API surface and load-time validation can block toolkit startup on bad trigger declarations or slug collisions across toolkits; auth behavior on `/worker/triggers` must match other worker routes.
> 
> **Overview**
> Adds **toolkit-declared trigger types** end to end: a new `TriggerType` model in **arcade-core** (webhook/poll metadata, JSON Schema validation for config/payload, duplicate-slug checks at load time) plus optional auto-load from `<package>.trigger_types`.
> 
> **ToolCatalog** now merges trigger types when toolkits are registered, rejects duplicate slugs as `ToolkitLoadError`, and skips trigger accumulation when a toolkit is disabled via `ARCADE_DISABLED_TOOLKITS` (disabled-toolkit matching now uses `toolkit.name` instead of `str(toolkit)`).
> 
> **arcade-serve** exposes authenticated **`GET /worker/triggers`** (default empty list for workers that do not override `get_trigger_types`). The integrated MCP worker forwards `catalog.trigger_types` after startup. Package bumps: **arcade-core** 4.11.1 (+ `jsonschema`), **arcade-serve** 3.4.3, **arcade-mcp-server** 1.26.1.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900c42b206bd34fea4f7e1aa54bb2bce6ab9a4ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->