### PR TITLE
Bump actions to current majors; add Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/cli-integration-no-auth.yml
+++ b/.github/workflows/cli-integration-no-auth.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Set up environment
               uses: ./.github/actions/setup-uv-env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v6
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up the environment
         uses: ./.github/actions/setup-uv-env

--- a/.github/workflows/pylon-sync.yml
+++ b/.github/workflows/pylon-sync.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set Up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.x"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v10
         with:
           version: "latest"
 

--- a/.github/workflows/release-on-version-change.yml
+++ b/.github/workflows/release-on-version-change.yml
@@ -16,7 +16,7 @@ jobs:
       has-changes: ${{ steps.set-matrix.outputs.has-changes }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -62,7 +62,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -141,7 +141,7 @@ jobs:
           echo "Built artifacts for ${{ env.PACKAGE_NAME }} v${{ env.VERSION }}"
 
       - name: Upload release distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dists-${{ env.PACKAGE_NAME }}-${{ env.VERSION }}
           path: ${{ matrix.package }}/dist/
@@ -156,7 +156,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -170,7 +170,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Retrieve release distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dists-${{ env.PACKAGE_NAME }}-${{ env.VERSION }}
           path: dist/

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -19,7 +19,7 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v7
 
             - name: Set up environment
               uses: ./.github/actions/setup-uv-env


### PR DESCRIPTION
Part of an org-wide sweep: every workflow run on the old pins emits Node 20 deprecation warnings (GitHub force-runs them on Node 24). Bumps all stale first-party pins to current majors and adds weekly Dependabot (`github-actions` ecosystem) so the next deprecation cycle arrives as automatic PRs. Please eyeball CI on this PR before merging — artifact/cache major jumps are usually inert but not guaranteed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U99AjT4THeqirpRGFRygTM

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to workflow pins and Dependabot config; release artifact steps use newer majors but behavior is typically unchanged—CI on this PR is the main validation gate.
> 
> **Overview**
> Updates CI to current **GitHub Actions** major versions so workflows stop running on deprecated Node 20 runners. Across **main**, **CLI integration**, **test-install**, **Pylon sync**, and **release-on-version-change**, `actions/checkout` moves to **v7**; **main** also bumps `actions/cache` to **v6**; the release workflow bumps **upload-artifact** to **v7** and **download-artifact** to **v8**; **Pylon sync** bumps `setup-python` to **v7** and `astral-sh/setup-uv` to **v10**.
> 
> Adds **`.github/dependabot.yaml`** with weekly updates for the **github-actions** ecosystem at repo root so future action bumps land as Dependabot PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a89eb631d4cd6b44e40c4e4efc820b3dc44a57bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->