### PR TITLE
refactor(core): move the MCP resource models into arcade-core [TOO-1931]

### DIFF
--- a/libs/arcade-core/arcade_core/resource_schema.py
+++ b/libs/arcade-core/arcade_core/resource_schema.py
@@ -1,0 +1,114 @@
+"""Resource schema for the worker format.
+
+The shapes a worker returns when a caller lists or reads the resources a
+toolkit ships: a listing entry, its contents as text or as a base64 blob, and
+the paginated results that carry them.
+
+Field names are spelled exactly as they go on the wire, including the
+underscore on ``_meta``, so nothing has to be renamed at either end.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Cursor = str
+Role = Literal["user", "assistant"]
+
+
+class Result(BaseModel):
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class PaginatedResult(Result):
+    nextCursor: Cursor | None = None
+
+
+class BaseMetadata(BaseModel):
+    name: str
+    title: str | None = None
+
+    # populate_by_name lets callers pass ``meta=`` for the ``_meta`` field. Without
+    # it, and with extra="allow", ``meta=`` is silently accepted as an extra field
+    # and serialized as ``meta``, which no caller reads.
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class Icon(BaseModel):
+    """Icon metadata."""
+
+    src: str
+    mimeType: str | None = None
+    sizes: list[str] | None = None
+    theme: Literal["light", "dark"] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Annotations(BaseModel):
+    audience: list[Role] | None = None
+    priority: float | None = None
+    lastModified: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Resource(BaseMetadata):
+    uri: str
+    description: str | None = None
+    mimeType: str | None = None
+    annotations: Annotations | None = None
+    size: int | None = None
+    icons: list[Icon] | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+
+class ListResourcesParams(BaseModel):
+    """Params for a resource listing request: an optional pagination cursor."""
+
+    cursor: Cursor | None = None
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class ListResourcesResult(PaginatedResult):
+    resources: list[Resource] = Field(default_factory=list)
+
+
+class ResourceTemplate(BaseMetadata):
+    uriTemplate: str
+    description: str | None = None
+    mimeType: str | None = None
+    annotations: Annotations | None = None
+    icons: list[Icon] | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+
+class ListResourceTemplatesResult(PaginatedResult):
+    resourceTemplates: list[ResourceTemplate] = Field(default_factory=list)
+
+
+class ReadResourceParams(BaseModel):
+    uri: str
+
+
+class ResourceContents(BaseModel):
+    uri: str
+    mimeType: str | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TextResourceContents(ResourceContents):
+    text: str
+
+
+class BlobResourceContents(ResourceContents):
+    blob: str
+
+
+class ReadResourceResult(Result):
+    contents: list[TextResourceContents | BlobResourceContents]

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.11.0"
+version = "4.12.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-mcp-server/arcade_mcp_server/types.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/types.py
@@ -3,6 +3,57 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
+from arcade_core.resource_schema import (
+    Annotations as Annotations,
+)
+from arcade_core.resource_schema import (
+    BaseMetadata as BaseMetadata,
+)
+from arcade_core.resource_schema import (
+    BlobResourceContents as BlobResourceContents,
+)
+from arcade_core.resource_schema import (
+    Cursor as Cursor,
+)
+from arcade_core.resource_schema import (
+    Icon as Icon,
+)
+from arcade_core.resource_schema import (
+    ListResourcesParams as ListResourcesParams,
+)
+from arcade_core.resource_schema import (
+    ListResourcesResult as ListResourcesResult,
+)
+from arcade_core.resource_schema import (
+    ListResourceTemplatesResult as ListResourceTemplatesResult,
+)
+from arcade_core.resource_schema import (
+    PaginatedResult as PaginatedResult,
+)
+from arcade_core.resource_schema import (
+    ReadResourceParams as ReadResourceParams,
+)
+from arcade_core.resource_schema import (
+    ReadResourceResult as ReadResourceResult,
+)
+from arcade_core.resource_schema import (
+    Resource as Resource,
+)
+from arcade_core.resource_schema import (
+    ResourceContents as ResourceContents,
+)
+from arcade_core.resource_schema import (
+    ResourceTemplate as ResourceTemplate,
+)
+from arcade_core.resource_schema import (
+    Result as Result,
+)
+from arcade_core.resource_schema import (
+    Role as Role,
+)
+from arcade_core.resource_schema import (
+    TextResourceContents as TextResourceContents,
+)
 from pydantic import BaseModel, ConfigDict, Field
 
 from arcade_mcp_server.resource_server.base import ResourceOwner
@@ -68,7 +119,6 @@ def version_has_feature(version: str, feature: str) -> bool:
 # -----------------------------------------------------------------------------
 
 ProgressToken = str | int
-Cursor = str
 RequestId = str | int
 AnyFunction: TypeAlias = Callable[..., Any]
 
@@ -88,12 +138,6 @@ class Request(BaseModel):
 class Notification(BaseModel):
     method: str
     params: Any = None
-
-    model_config = ConfigDict(extra="allow", populate_by_name=True)
-
-
-class Result(BaseModel):
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -155,24 +199,6 @@ class SessionMessage:
 # -----------------------------------------------------------------------------
 # Initialization
 # -----------------------------------------------------------------------------
-
-
-class BaseMetadata(BaseModel):
-    name: str
-    title: str | None = None
-
-    model_config = ConfigDict(extra="allow")
-
-
-class Icon(BaseModel):
-    """Icon metadata (MCP 2025-11-25)."""
-
-    src: str
-    mimeType: str | None = None
-    sizes: list[str] | None = None
-    theme: Literal["light", "dark"] | None = None
-
-    model_config = ConfigDict(extra="allow")
 
 
 class Implementation(BaseMetadata):
@@ -269,46 +295,13 @@ class PaginatedRequest(JSONRPCRequest):
     params: dict[str, Any] | None = None
 
 
-class PaginatedResult(Result):
-    nextCursor: Cursor | None = None
-
-
-# -----------------------------------------------------------------------------
-# Annotations (used across resources, content, etc.)
-# -----------------------------------------------------------------------------
-
-Role = Literal["user", "assistant"]
-
-
-class Annotations(BaseModel):
-    audience: list[Role] | None = None
-    priority: float | None = None
-    lastModified: str | None = None
-
-    model_config = ConfigDict(extra="allow")
-
-
 # -----------------------------------------------------------------------------
 # Resources
 # -----------------------------------------------------------------------------
 
 
-class Resource(BaseMetadata):
-    uri: str
-    description: str | None = None
-    mimeType: str | None = None
-    annotations: Annotations | None = None
-    size: int | None = None
-    icons: list[Icon] | None = None
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
-
-
 class ListResourcesRequest(PaginatedRequest):
     method: Literal["resources/list"] = Field(default="resources/list", frozen=True)
-
-
-class ListResourcesResult(PaginatedResult):
-    resources: list[Resource] = Field(default_factory=list)
 
 
 class ListResourceTemplatesRequest(PaginatedRequest):
@@ -317,44 +310,9 @@ class ListResourceTemplatesRequest(PaginatedRequest):
     )
 
 
-class ResourceTemplate(BaseMetadata):
-    uriTemplate: str
-    description: str | None = None
-    mimeType: str | None = None
-    annotations: Annotations | None = None
-    icons: list[Icon] | None = None
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
-
-
-class ListResourceTemplatesResult(PaginatedResult):
-    resourceTemplates: list[ResourceTemplate] = Field(default_factory=list)
-
-
-class ReadResourceParams(BaseModel):
-    uri: str
-
-
 class ReadResourceRequest(JSONRPCRequest):
     method: Literal["resources/read"] = Field(default="resources/read", frozen=True)
     params: ReadResourceParams
-
-
-class ResourceContents(BaseModel):
-    uri: str
-    mimeType: str | None = None
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
-
-
-class TextResourceContents(ResourceContents):
-    text: str
-
-
-class BlobResourceContents(ResourceContents):
-    blob: str
-
-
-class ReadResourceResult(Result):
-    contents: list[TextResourceContents | BlobResourceContents]
 
 
 class ResourceListChangedNotification(JSONRPCMessage, Notification):

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.26.0"
+version = "1.26.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.11.0,<5.0.0",
+    "arcade-core>=4.12.0,<5.0.0",
     "arcade-serve>=3.4.0,<4.0.0",
     "arcade-tdk>=3.10.1,<4.0.0",
     "arcadepy>=1.5.0",

--- a/libs/tests/arcade_mcp_server/test_types_reexport.py
+++ b/libs/tests/arcade_mcp_server/test_types_reexport.py
@@ -1,0 +1,41 @@
+"""The resource models live in arcade-core; arcade_mcp_server re-exports them.
+
+arcade-serve needs these shapes and cannot import arcade-mcp-server, since the
+dependency runs the other way. Anything importing them from the old location
+must keep getting the same class object, not a copy.
+"""
+
+from arcade_core import resource_schema as core_resources
+from arcade_mcp_server import types as mcp_types
+
+MOVED = [
+    "Annotations",
+    "BaseMetadata",
+    "BlobResourceContents",
+    "Cursor",
+    "Icon",
+    "ListResourceTemplatesResult",
+    "ListResourcesParams",
+    "ListResourcesResult",
+    "PaginatedResult",
+    "ReadResourceParams",
+    "ReadResourceResult",
+    "Resource",
+    "ResourceContents",
+    "ResourceTemplate",
+    "Result",
+    "Role",
+    "TextResourceContents",
+]
+
+
+def test_moved_names_are_the_same_objects():
+    for name in MOVED:
+        assert getattr(mcp_types, name) is getattr(core_resources, name), name
+
+
+def test_json_rpc_request_envelopes_stayed_behind():
+    """The worker protocol carries params and results, never a JSON-RPC envelope."""
+    for name in ("ListResourcesRequest", "ListResourceTemplatesRequest", "ReadResourceRequest"):
+        assert hasattr(mcp_types, name)
+        assert not hasattr(core_resources, name)

--- a/libs/tests/core/test_resource_schema.py
+++ b/libs/tests/core/test_resource_schema.py
@@ -1,0 +1,120 @@
+"""The resource schema must serialize exactly as it goes on the wire.
+
+The field names, the ``_meta`` alias, and the text-versus-blob distinction are
+wire contract rather than internal detail: a caller decodes these bytes, so a
+renamed field or a collapsed distinction is a break.
+"""
+
+import pytest
+from arcade_core.resource_schema import (
+    BlobResourceContents,
+    ListResourcesParams,
+    ListResourcesResult,
+    ReadResourceResult,
+    Resource,
+    TextResourceContents,
+)
+from pydantic import ValidationError
+
+
+def test_resource_serializes_meta_under_the_underscore_key():
+    resource = Resource(
+        uri="ui://Gmail/8.1.0/draft.html",
+        name="Draft review",
+        mimeType="text/html;profile=example",
+        meta={"ui": {"csp": {"resourceDomains": ["https://cdn.example.com"]}}},
+    )
+
+    dumped = resource.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["_meta"] == {"ui": {"csp": {"resourceDomains": ["https://cdn.example.com"]}}}
+    assert "meta" not in dumped
+
+
+def test_resource_accepts_the_underscore_key_on_the_way_in():
+    resource = Resource.model_validate({
+        "uri": "ui://Gmail/8.1.0/draft.html",
+        "name": "Draft review",
+        "_meta": {"ui": {"prefersBorder": True}},
+    })
+
+    assert resource.meta == {"ui": {"prefersBorder": True}}
+
+
+def test_mime_type_is_carried_byte_for_byte():
+    """A host that renders an interface compares this with string equality."""
+    resource = Resource(uri="ui://x/1.0.0/a.html", name="a", mimeType="text/html;profile=example")
+
+    assert resource.model_dump(by_alias=True)["mimeType"] == "text/html;profile=example"
+
+
+def test_empty_text_and_empty_blob_stay_distinguishable():
+    text = ReadResourceResult(contents=[TextResourceContents(uri="res://a", text="")])
+    blob = ReadResourceResult(contents=[BlobResourceContents(uri="res://a", blob="")])
+
+    text_dumped = text.model_dump(by_alias=True, exclude_none=True)["contents"][0]
+    blob_dumped = blob.model_dump(by_alias=True, exclude_none=True)["contents"][0]
+
+    assert text_dumped == {"uri": "res://a", "text": ""}
+    assert blob_dumped == {"uri": "res://a", "blob": ""}
+    assert text_dumped != blob_dumped
+
+
+def test_blob_stays_a_string_and_is_never_re_encoded():
+    """A bytes-typed field would normalize padding and alphabet on every read."""
+    padded = "YQ=="
+    result = ReadResourceResult.model_validate({"contents": [{"uri": "res://a", "blob": padded}]})
+
+    assert isinstance(result.contents[0], BlobResourceContents)
+    assert result.contents[0].blob == padded
+
+
+def test_read_result_round_trips_a_mixed_contents_list():
+    payload = {
+        "contents": [
+            {"uri": "res://t", "mimeType": "text/plain", "text": "hello"},
+            {"uri": "res://b", "mimeType": "application/octet-stream", "blob": "AAEC"},
+        ]
+    }
+
+    result = ReadResourceResult.model_validate(payload)
+
+    assert isinstance(result.contents[0], TextResourceContents)
+    assert isinstance(result.contents[1], BlobResourceContents)
+    assert result.model_dump(by_alias=True, exclude_none=True) == payload
+
+
+def test_list_result_defaults_to_an_empty_page():
+    result = ListResourcesResult()
+
+    assert result.resources == []
+    assert result.model_dump(by_alias=True, exclude_none=True) == {"resources": []}
+
+
+def test_list_params_accept_an_absent_cursor():
+    """A first-page request sends an empty body, which the router coerces to {}."""
+    assert ListResourcesParams.model_validate({}).cursor is None
+    assert ListResourcesParams.model_validate({"cursor": "b2Zmc2V0OjI="}).cursor == "b2Zmc2V0OjI="
+
+
+def test_resource_requires_a_uri_and_a_name():
+    with pytest.raises(ValidationError):
+        Resource(name="missing uri")
+    with pytest.raises(ValidationError):
+        Resource(uri="ui://x/1.0.0/a.html")
+
+
+def test_meta_keyword_reaches_the_aliased_field_rather_than_extras():
+    """``meta=`` must land on ``_meta``.
+
+    With extra="allow" and no populate_by_name, pydantic accepts ``meta=`` as an
+    extra field and emits it as ``meta``. A caller reads only ``_meta``, so a
+    developer-declared CSP would vanish with no error anywhere.
+    """
+    resource = Resource(uri="ui://x/1.0.0/a.html", name="a", meta={"ui": {"csp": {}}})
+    contents = TextResourceContents(uri="ui://x/1.0.0/a.html", text="<html>", meta={"ui": {}})
+
+    assert resource.meta == {"ui": {"csp": {}}}
+    assert contents.meta == {"ui": {}}
+    assert "meta" not in resource.model_dump(by_alias=True)
+    assert "meta" not in contents.model_dump(by_alias=True)


### PR DESCRIPTION
Part 1 of 6 in the M1 stack for [Support Resources for Engine-to-Worker Leg](https://linear.app/arcadedev/project/support-resources-for-engine-to-worker-leg-d486c70976cb). Linear: TOO-1931.

## Why

`arcade-serve` needs MCP's resource shapes to serve them on the worker protocol, and it cannot import `arcade-mcp-server`, because the dependency runs the other way. This moves the result-shaped half of the resource surface into `arcade-core` and re-exports it from `arcade_mcp_server.types`, so both libraries read one definition.

## What moved, and what did not

Moved: `Result`, `PaginatedResult`, `BaseMetadata`, `Icon`, `Annotations`, `Cursor`, `Role`, `Resource`, `ResourceTemplate`, `ResourceContents`, `TextResourceContents`, `BlobResourceContents`, `ListResourcesResult`, `ListResourceTemplatesResult`, `ReadResourceResult`, `ReadResourceParams`.

**The three JSON-RPC request envelopes stay behind.** `ListResourcesRequest` and its siblings extend `JSONRPCRequest`, which would pull `JSONRPCMessage`, `Request` and `RequestId` into arcade-core to no purpose: a transport that is not JSON-RPC carries the params object alone.

`ListResourcesParams` is new, because arcade-mcp-server never modelled it (`PaginatedRequest.params` is a bare `dict[str, Any]`). The class name is local; the wire shape is MCP's `PaginatedRequestParams` exactly.

## A live bug this fixes

`Resource`, `ResourceTemplate` and `ResourceContents` declare `meta` with `alias="_meta"`, but their config never set `populate_by_name`. With `extra="allow"`, that means `Resource(meta=...)` was silently accepted as an **extra field** and serialized as `"meta"`:

```
>>> Resource(uri="u", name="n", meta={"ui": {"x": 1}}).model_dump(by_alias=True, exclude_none=True)
{"name": "n", "uri": "u", "meta": {"ui": {"x": 1}}}     # and .meta reads None
```

No MCP client reads `meta`, so a developer-declared `_meta.ui.csp` would have vanished with no error at any layer. `Result` already had `populate_by_name`, which is why the two behaved differently. Fixed here with a regression test, since these are the models being moved.

## Verification

- 3745 passed, 1 skipped across `libs/tests`.
- `mypy` clean on arcade-core and arcade-mcp-server.
- New: 10 model tests in `libs/tests/core/test_mcp_resources.py`, plus a re-export identity test asserting the moved names are the same objects and the request envelopes stayed behind.