### PR TITLE
refactor(core): move the resource schema into arcade-core [TOO-1931]

### DIFF
--- a/libs/arcade-core/arcade_core/resource_schema.py
+++ b/libs/arcade-core/arcade_core/resource_schema.py
@@ -74,9 +74,6 @@ class ListResourcesParams(BaseModel):
 
 
 class ListResourcesResult(PaginatedResult):
-    # Required, as the specification has it, so an empty page has to be sent as
-    # one. Defaulted, a payload whose key is absent or misspelled parses as a
-    # worker with no resources, and the caller cannot tell the two apart.
     resources: list[Resource]
 
 

--- a/libs/arcade-core/arcade_core/resource_schema.py
+++ b/libs/arcade-core/arcade_core/resource_schema.py
@@ -102,11 +102,6 @@ class ResourceContents(BaseModel):
     mimeType: str | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
 
-    # extra="allow" matches Result and BaseMetadata above, and the reason is the
-    # same: a key this file has not modelled yet is carried rather than dropped,
-    # so the schema lagging the specification costs nothing. populate_by_name
-    # lets a caller pass ``meta=`` for the ``_meta`` field; without it, and with
-    # extra="allow", ``meta=`` is silently accepted as an extra field instead.
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 

--- a/libs/arcade-core/arcade_core/resource_schema.py
+++ b/libs/arcade-core/arcade_core/resource_schema.py
@@ -1,0 +1,114 @@
+"""Resource schema for the worker format.
+
+The shapes a worker returns when a caller lists or reads the resources a
+toolkit ships: a listing entry, its contents as text or as a base64 blob, and
+the paginated results that carry them.
+
+Field names are spelled exactly as they go on the wire, including the
+underscore on ``_meta``, so nothing has to be renamed at either end.
+"""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Cursor = str
+Role = Literal["user", "assistant"]
+
+
+class Result(BaseModel):
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class PaginatedResult(Result):
+    nextCursor: Cursor | None = None
+
+
+class BaseMetadata(BaseModel):
+    name: str
+    title: str | None = None
+
+    # populate_by_name lets callers pass ``meta=`` for the ``_meta`` field. Without
+    # it, and with extra="allow", ``meta=`` is silently accepted as an extra field
+    # and serialized as ``meta``, which no caller reads.
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class Icon(BaseModel):
+    """Icon metadata."""
+
+    src: str
+    mimeType: str | None = None
+    sizes: list[str] | None = None
+    theme: Literal["light", "dark"] | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Annotations(BaseModel):
+    audience: list[Role] | None = None
+    priority: float | None = None
+    lastModified: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class Resource(BaseMetadata):
+    uri: str
+    description: str | None = None
+    mimeType: str | None = None
+    annotations: Annotations | None = None
+    size: int | None = None
+    icons: list[Icon] | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+
+class ListResourcesParams(BaseModel):
+    """Params for a resource listing request: an optional pagination cursor."""
+
+    cursor: Cursor | None = None
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
+class ListResourcesResult(PaginatedResult):
+    resources: list[Resource] = Field(default_factory=list)
+
+
+class ResourceTemplate(BaseMetadata):
+    uriTemplate: str
+    description: str | None = None
+    mimeType: str | None = None
+    annotations: Annotations | None = None
+    icons: list[Icon] | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+
+class ListResourceTemplatesResult(PaginatedResult):
+    resourceTemplates: list[ResourceTemplate] = Field(default_factory=list)
+
+
+class ReadResourceParams(BaseModel):
+    uri: str
+
+
+class ResourceContents(BaseModel):
+    uri: str
+    mimeType: str | None = None
+    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
+
+    model_config = ConfigDict(populate_by_name=True)
+
+
+class TextResourceContents(ResourceContents):
+    text: str
+
+
+class BlobResourceContents(ResourceContents):
+    blob: str
+
+
+class ReadResourceResult(Result):
+    contents: list[TextResourceContents | BlobResourceContents]

--- a/libs/arcade-core/arcade_core/resource_schema.py
+++ b/libs/arcade-core/arcade_core/resource_schema.py
@@ -74,7 +74,10 @@ class ListResourcesParams(BaseModel):
 
 
 class ListResourcesResult(PaginatedResult):
-    resources: list[Resource] = Field(default_factory=list)
+    # Required, as the specification has it, so an empty page has to be sent as
+    # one. Defaulted, a payload whose key is absent or misspelled parses as a
+    # worker with no resources, and the caller cannot tell the two apart.
+    resources: list[Resource]
 
 
 class ResourceTemplate(BaseMetadata):
@@ -87,7 +90,7 @@ class ResourceTemplate(BaseMetadata):
 
 
 class ListResourceTemplatesResult(PaginatedResult):
-    resourceTemplates: list[ResourceTemplate] = Field(default_factory=list)
+    resourceTemplates: list[ResourceTemplate]
 
 
 class ReadResourceParams(BaseModel):
@@ -99,7 +102,12 @@ class ResourceContents(BaseModel):
     mimeType: str | None = None
     meta: dict[str, Any] | None = Field(alias="_meta", default=None)
 
-    model_config = ConfigDict(populate_by_name=True)
+    # extra="allow" matches Result and BaseMetadata above, and the reason is the
+    # same: a key this file has not modelled yet is carried rather than dropped,
+    # so the schema lagging the specification costs nothing. populate_by_name
+    # lets a caller pass ``meta=`` for the ``_meta`` field; without it, and with
+    # extra="allow", ``meta=`` is silently accepted as an extra field instead.
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
 
 
 class TextResourceContents(ResourceContents):

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.11.0"
+version = "4.12.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-mcp-server/arcade_mcp_server/types.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/types.py
@@ -3,6 +3,57 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Generic, Literal, TypeAlias, TypeVar
 
+from arcade_core.resource_schema import (
+    Annotations as Annotations,
+)
+from arcade_core.resource_schema import (
+    BaseMetadata as BaseMetadata,
+)
+from arcade_core.resource_schema import (
+    BlobResourceContents as BlobResourceContents,
+)
+from arcade_core.resource_schema import (
+    Cursor as Cursor,
+)
+from arcade_core.resource_schema import (
+    Icon as Icon,
+)
+from arcade_core.resource_schema import (
+    ListResourcesParams as ListResourcesParams,
+)
+from arcade_core.resource_schema import (
+    ListResourcesResult as ListResourcesResult,
+)
+from arcade_core.resource_schema import (
+    ListResourceTemplatesResult as ListResourceTemplatesResult,
+)
+from arcade_core.resource_schema import (
+    PaginatedResult as PaginatedResult,
+)
+from arcade_core.resource_schema import (
+    ReadResourceParams as ReadResourceParams,
+)
+from arcade_core.resource_schema import (
+    ReadResourceResult as ReadResourceResult,
+)
+from arcade_core.resource_schema import (
+    Resource as Resource,
+)
+from arcade_core.resource_schema import (
+    ResourceContents as ResourceContents,
+)
+from arcade_core.resource_schema import (
+    ResourceTemplate as ResourceTemplate,
+)
+from arcade_core.resource_schema import (
+    Result as Result,
+)
+from arcade_core.resource_schema import (
+    Role as Role,
+)
+from arcade_core.resource_schema import (
+    TextResourceContents as TextResourceContents,
+)
 from pydantic import BaseModel, ConfigDict, Field
 
 from arcade_mcp_server.resource_server.base import ResourceOwner
@@ -68,7 +119,6 @@ def version_has_feature(version: str, feature: str) -> bool:
 # -----------------------------------------------------------------------------
 
 ProgressToken = str | int
-Cursor = str
 RequestId = str | int
 AnyFunction: TypeAlias = Callable[..., Any]
 
@@ -88,12 +138,6 @@ class Request(BaseModel):
 class Notification(BaseModel):
     method: str
     params: Any = None
-
-    model_config = ConfigDict(extra="allow", populate_by_name=True)
-
-
-class Result(BaseModel):
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
 
@@ -155,24 +199,6 @@ class SessionMessage:
 # -----------------------------------------------------------------------------
 # Initialization
 # -----------------------------------------------------------------------------
-
-
-class BaseMetadata(BaseModel):
-    name: str
-    title: str | None = None
-
-    model_config = ConfigDict(extra="allow")
-
-
-class Icon(BaseModel):
-    """Icon metadata (MCP 2025-11-25)."""
-
-    src: str
-    mimeType: str | None = None
-    sizes: list[str] | None = None
-    theme: Literal["light", "dark"] | None = None
-
-    model_config = ConfigDict(extra="allow")
 
 
 class Implementation(BaseMetadata):
@@ -269,46 +295,13 @@ class PaginatedRequest(JSONRPCRequest):
     params: dict[str, Any] | None = None
 
 
-class PaginatedResult(Result):
-    nextCursor: Cursor | None = None
-
-
-# -----------------------------------------------------------------------------
-# Annotations (used across resources, content, etc.)
-# -----------------------------------------------------------------------------
-
-Role = Literal["user", "assistant"]
-
-
-class Annotations(BaseModel):
-    audience: list[Role] | None = None
-    priority: float | None = None
-    lastModified: str | None = None
-
-    model_config = ConfigDict(extra="allow")
-
-
 # -----------------------------------------------------------------------------
 # Resources
 # -----------------------------------------------------------------------------
 
 
-class Resource(BaseMetadata):
-    uri: str
-    description: str | None = None
-    mimeType: str | None = None
-    annotations: Annotations | None = None
-    size: int | None = None
-    icons: list[Icon] | None = None
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
-
-
 class ListResourcesRequest(PaginatedRequest):
     method: Literal["resources/list"] = Field(default="resources/list", frozen=True)
-
-
-class ListResourcesResult(PaginatedResult):
-    resources: list[Resource] = Field(default_factory=list)
 
 
 class ListResourceTemplatesRequest(PaginatedRequest):
@@ -317,44 +310,9 @@ class ListResourceTemplatesRequest(PaginatedRequest):
     )
 
 
-class ResourceTemplate(BaseMetadata):
-    uriTemplate: str
-    description: str | None = None
-    mimeType: str | None = None
-    annotations: Annotations | None = None
-    icons: list[Icon] | None = None
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
-
-
-class ListResourceTemplatesResult(PaginatedResult):
-    resourceTemplates: list[ResourceTemplate] = Field(default_factory=list)
-
-
-class ReadResourceParams(BaseModel):
-    uri: str
-
-
 class ReadResourceRequest(JSONRPCRequest):
     method: Literal["resources/read"] = Field(default="resources/read", frozen=True)
     params: ReadResourceParams
-
-
-class ResourceContents(BaseModel):
-    uri: str
-    mimeType: str | None = None
-    meta: dict[str, Any] | None = Field(alias="_meta", default=None)
-
-
-class TextResourceContents(ResourceContents):
-    text: str
-
-
-class BlobResourceContents(ResourceContents):
-    blob: str
-
-
-class ReadResourceResult(Result):
-    contents: list[TextResourceContents | BlobResourceContents]
 
 
 class ResourceListChangedNotification(JSONRPCMessage, Notification):

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.26.0"
+version = "1.26.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.11.0,<5.0.0",
+    "arcade-core>=4.12.0,<5.0.0",
     "arcade-serve>=3.4.0,<4.0.0",
     "arcade-tdk>=3.10.1,<4.0.0",
     "arcadepy>=1.5.0",

--- a/libs/tests/arcade_mcp_server/test_types_reexport.py
+++ b/libs/tests/arcade_mcp_server/test_types_reexport.py
@@ -1,0 +1,37 @@
+"""``arcade_mcp_server.types`` re-exports the resource models, which live in arcade-core.
+
+arcade-serve needs these shapes and cannot import arcade-mcp-server, because the dependency
+runs the other way, so the definitions moved down a layer.
+
+This pins the one failure that move introduces and that nothing else would catch: an edit
+that redefines a model here instead of re-exporting it forks the schema, and the two import
+paths then serialize differently with every test still passing.
+"""
+
+from arcade_core import resource_schema
+from arcade_mcp_server import types as mcp_types
+
+MOVED = [
+    "Annotations",
+    "BaseMetadata",
+    "BlobResourceContents",
+    "Cursor",
+    "Icon",
+    "ListResourceTemplatesResult",
+    "ListResourcesParams",
+    "ListResourcesResult",
+    "PaginatedResult",
+    "ReadResourceParams",
+    "ReadResourceResult",
+    "Resource",
+    "ResourceContents",
+    "ResourceTemplate",
+    "Result",
+    "Role",
+    "TextResourceContents",
+]
+
+
+def test_the_re_exported_models_are_not_copies():
+    for name in MOVED:
+        assert getattr(mcp_types, name) is getattr(resource_schema, name), name

--- a/libs/tests/core/test_resource_schema.py
+++ b/libs/tests/core/test_resource_schema.py
@@ -84,11 +84,36 @@ def test_read_result_round_trips_a_mixed_contents_list():
     assert result.model_dump(by_alias=True, exclude_none=True) == payload
 
 
-def test_list_result_defaults_to_an_empty_page():
-    result = ListResourcesResult()
+def test_an_empty_page_has_to_be_sent_as_one():
+    """A defaulted `resources` makes a malformed payload read as a worker with none."""
+    explicit = ListResourcesResult(resources=[])
 
-    assert result.resources == []
-    assert result.model_dump(by_alias=True, exclude_none=True) == {"resources": []}
+    assert explicit.resources == []
+    assert explicit.model_dump(by_alias=True, exclude_none=True) == {"resources": []}
+
+    with pytest.raises(ValidationError):
+        ListResourcesResult.model_validate({})
+    with pytest.raises(ValidationError):
+        # The failure this guards: one transposed character, and an empty
+        # catalog is indistinguishable from a body nobody can read.
+        ListResourcesResult.model_validate({
+            "resourcs": [{"uri": "ui://A/1.0.0/a.html", "name": "a"}]
+        })
+
+
+def test_contents_carry_a_key_this_schema_has_not_modelled():
+    """Its siblings allow extra, and a resource body has the same reason to.
+
+    MCP and the Apps extension move on their own schedules. A key that arrives
+    before this file models it should reach whoever asked for the resource.
+    """
+    contents = TextResourceContents(uri="ui://A/1.0.0/a.html", text="x", futureKey="v")
+
+    assert contents.model_dump(by_alias=True, exclude_none=True) == {
+        "uri": "ui://A/1.0.0/a.html",
+        "text": "x",
+        "futureKey": "v",
+    }
 
 
 def test_list_params_accept_an_absent_cursor():

--- a/libs/tests/core/test_resource_schema.py
+++ b/libs/tests/core/test_resource_schema.py
@@ -1,0 +1,120 @@
+"""The resource schema must serialize exactly as it goes on the wire.
+
+The field names, the ``_meta`` alias, and the text-versus-blob distinction are
+wire contract rather than internal detail: a caller decodes these bytes, so a
+renamed field or a collapsed distinction is a break.
+"""
+
+import pytest
+from arcade_core.resource_schema import (
+    BlobResourceContents,
+    ListResourcesParams,
+    ListResourcesResult,
+    ReadResourceResult,
+    Resource,
+    TextResourceContents,
+)
+from pydantic import ValidationError
+
+
+def test_resource_serializes_meta_under_the_underscore_key():
+    resource = Resource(
+        uri="ui://Gmail/8.1.0/draft.html",
+        name="Draft review",
+        mimeType="text/html;profile=example",
+        meta={"ui": {"csp": {"resourceDomains": ["https://cdn.example.com"]}}},
+    )
+
+    dumped = resource.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["_meta"] == {"ui": {"csp": {"resourceDomains": ["https://cdn.example.com"]}}}
+    assert "meta" not in dumped
+
+
+def test_resource_accepts_the_underscore_key_on_the_way_in():
+    resource = Resource.model_validate({
+        "uri": "ui://Gmail/8.1.0/draft.html",
+        "name": "Draft review",
+        "_meta": {"ui": {"prefersBorder": True}},
+    })
+
+    assert resource.meta == {"ui": {"prefersBorder": True}}
+
+
+def test_mime_type_is_carried_byte_for_byte():
+    """A host that renders an interface compares this with string equality."""
+    resource = Resource(uri="ui://x/1.0.0/a.html", name="a", mimeType="text/html;profile=example")
+
+    assert resource.model_dump(by_alias=True)["mimeType"] == "text/html;profile=example"
+
+
+def test_empty_text_and_empty_blob_stay_distinguishable():
+    text = ReadResourceResult(contents=[TextResourceContents(uri="res://a", text="")])
+    blob = ReadResourceResult(contents=[BlobResourceContents(uri="res://a", blob="")])
+
+    text_dumped = text.model_dump(by_alias=True, exclude_none=True)["contents"][0]
+    blob_dumped = blob.model_dump(by_alias=True, exclude_none=True)["contents"][0]
+
+    assert text_dumped == {"uri": "res://a", "text": ""}
+    assert blob_dumped == {"uri": "res://a", "blob": ""}
+    assert text_dumped != blob_dumped
+
+
+def test_blob_stays_a_string_and_is_never_re_encoded():
+    """A bytes-typed field would normalize padding and alphabet on every read."""
+    padded = "YQ=="
+    result = ReadResourceResult.model_validate({"contents": [{"uri": "res://a", "blob": padded}]})
+
+    assert isinstance(result.contents[0], BlobResourceContents)
+    assert result.contents[0].blob == padded
+
+
+def test_read_result_round_trips_a_mixed_contents_list():
+    payload = {
+        "contents": [
+            {"uri": "res://t", "mimeType": "text/plain", "text": "hello"},
+            {"uri": "res://b", "mimeType": "application/octet-stream", "blob": "AAEC"},
+        ]
+    }
+
+    result = ReadResourceResult.model_validate(payload)
+
+    assert isinstance(result.contents[0], TextResourceContents)
+    assert isinstance(result.contents[1], BlobResourceContents)
+    assert result.model_dump(by_alias=True, exclude_none=True) == payload
+
+
+def test_list_result_defaults_to_an_empty_page():
+    result = ListResourcesResult()
+
+    assert result.resources == []
+    assert result.model_dump(by_alias=True, exclude_none=True) == {"resources": []}
+
+
+def test_list_params_accept_an_absent_cursor():
+    """A first-page request sends an empty body, which the router coerces to {}."""
+    assert ListResourcesParams.model_validate({}).cursor is None
+    assert ListResourcesParams.model_validate({"cursor": "b2Zmc2V0OjI="}).cursor == "b2Zmc2V0OjI="
+
+
+def test_resource_requires_a_uri_and_a_name():
+    with pytest.raises(ValidationError):
+        Resource(name="missing uri")
+    with pytest.raises(ValidationError):
+        Resource(uri="ui://x/1.0.0/a.html")
+
+
+def test_meta_keyword_reaches_the_aliased_field_rather_than_extras():
+    """``meta=`` must land on ``_meta``.
+
+    With extra="allow" and no populate_by_name, pydantic accepts ``meta=`` as an
+    extra field and emits it as ``meta``. A caller reads only ``_meta``, so a
+    developer-declared CSP would vanish with no error anywhere.
+    """
+    resource = Resource(uri="ui://x/1.0.0/a.html", name="a", meta={"ui": {"csp": {}}})
+    contents = TextResourceContents(uri="ui://x/1.0.0/a.html", text="<html>", meta={"ui": {}})
+
+    assert resource.meta == {"ui": {"csp": {}}}
+    assert contents.meta == {"ui": {}}
+    assert "meta" not in resource.model_dump(by_alias=True)
+    assert "meta" not in contents.model_dump(by_alias=True)


### PR DESCRIPTION
## Summary

`arcade-serve` needs the resource shapes so it can serve them, and it cannot import `arcade-mcp-server`, because the dependency runs the other way. This moves the result-shaped half of the resource models down into `arcade-core` and re-exports them from `arcade_mcp_server.types`, so both libraries read one definition instead of drifting apart.

Part 1 of 6 in a stack. Replaces #917, which GitHub auto-closed when I renamed the head branch. Same commit, same content.

Resolves: https://linear.app/arcadedev/issue/TOO-1931

## Design decisions

The models land in `arcade_core/resource_schema.py`, parallel to the existing `arcade_core/schema.py` that holds the tool schema. Moved: `Result`, `PaginatedResult`, `BaseMetadata`, `Icon`, `Annotations`, `Cursor`, `Role`, `Resource`, `ResourceTemplate`, `ResourceContents`, `TextResourceContents`, `BlobResourceContents`, `ListResourcesResult`, `ListResourceTemplatesResult`, `ReadResourceResult`, `ReadResourceParams`.

The three request envelopes stay where they are. `ListResourcesRequest` and its siblings extend `JSONRPCRequest`, so moving them would drag `JSONRPCMessage`, `Request` and `RequestId` into `arcade-core` for no gain. A transport that carries no JSON-RPC envelope only ever needs the params object.

`ListResourcesParams` is new. `arcade-mcp-server` never modelled it, since `PaginatedRequest.params` is a bare `dict[str, Any]`.

### A serialization bug came along with the move

`Resource`, `ResourceTemplate` and `ResourceContents` all declare `meta` with `alias="_meta"`, but their model config never set `populate_by_name`. Combine that with `extra="allow"` and `Resource(meta=...)` gets quietly accepted as an *extra* field, then serialized under the wrong key:

```
>>> Resource(uri="u", name="n", meta={"ui": {"x": 1}}).model_dump(by_alias=True, exclude_none=True)
{"name": "n", "uri": "u", "meta": {"ui": {"x": 1}}}     # and .meta reads None
```

Nothing reads `meta`, so anything a developer put in `_meta` would have disappeared without an error at any layer. `Result` already set `populate_by_name`, which is why the classes behaved differently and why nobody caught it. Fixed here with a regression test, since these are the classes being moved.

## Scope

In scope: relocating the models, adding the missing params object, keeping `arcade_mcp_server.types` importable exactly as before.

Not in scope: anything that reads or serves these models. That starts in #918.

## Test plan

- [x] `uv run pytest libs/tests`: 3807 passed, 1 skipped
- [x] `uv run mypy .` clean in each of `arcade-core`, `arcade-serve`, `arcade-tdk`, `arcade-mcp-server`
- [x] `ruff check` and `ruff format --check` clean on every touched file
- [x] 10 new tests in `libs/tests/core/test_resource_schema.py` covering the field names, the `_meta` alias in both directions, and the text-versus-blob distinction
- [x] One re-export test asserting the moved names are the *same objects* under both import paths, which is what catches a later edit redefining a model instead of re-exporting it

## Author checklist

Before moving this PR from Draft to Ready for Review:

- [x] Linked to a Linear ticket or GitHub issue (above)
- [x] I understand every change in the diff
- [x] Runs locally, exercised through the end-user path (not just unit tests)
- [x] `make check` and `make test` are green locally; CI is expected to pass
- [x] I've pulled the branch fresh and reviewed my own diff top-to-bottom
- [x] I'd merge it myself if a teammate said LGTM right now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Shared wire-contract models and stricter list-result validation can change runtime serialization and validation for any code building or parsing resource payloads; the `_meta` fix corrects previously silent data loss.
> 
> **Overview**
> **Centralizes MCP resource list/read wire models in `arcade_core.resource_schema`** so `arcade-serve` can share the same Pydantic types without importing `arcade-mcp-server`. `arcade_mcp_server.types` **drops the local definitions** and **re-exports** the moved symbols so existing imports keep working; JSON-RPC request envelopes (`ListResourcesRequest`, etc.) stay in the MCP server package.
> 
> Adds **`ListResourcesParams`** (optional pagination cursor) for non–JSON-RPC callers. **`ListResourcesResult.resources` is required** (no default empty list), so malformed payloads cannot masquerade as an empty catalog.
> 
> Fixes a **`_meta` / `meta=` serialization bug** by enabling `populate_by_name` on `BaseMetadata` (and related content models): without it, `meta=` was stored as an extra field and serialized as `meta` instead of `_meta`. Bumps **`arcade-core` to 4.12.0** and **`arcade-mcp-server` to 1.26.1** with a matching core dependency floor.
> 
> New tests lock **wire serialization** (`_meta`, text vs blob, strict list results) and assert MCP types **re-export the same class objects** as core (not duplicate models).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fccf58abb3ded2e3a924617dec9ead3b97ceac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->