### PR TITLE
fix(core): only discover tools a module can bind [TOO-2002]

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -312,7 +312,17 @@ class ToolCatalog(BaseModel):
             for tool_name in tool_names:
                 try:
                     module = import_module(module_name)
-                    tool_func = getattr(module, tool_name)
+                    tool_func = getattr(module, tool_name, None)
+                    if tool_func is None:
+                        # Discovery reads the source, so a tool the module guards
+                        # behind something false at import time is found there and
+                        # absent here. Skipping is what stops one unreachable
+                        # declaration taking the rest of the toolkit offline.
+                        logger.warning(
+                            f"{module_name}.{tool_name} is decorated with @tool but the module "
+                            f"does not define it. Skipping it."
+                        )
+                        continue
                     self.add_tool(
                         tool_func,
                         toolkit,

--- a/libs/arcade-core/arcade_core/parse.py
+++ b/libs/arcade-core/arcade_core/parse.py
@@ -1,4 +1,5 @@
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 
 
@@ -61,14 +62,35 @@ def get_tools_from_file(filepath: str | Path) -> list[str]:
     return get_tools_from_ast(tree)
 
 
+def _module_scope_functions(node: ast.AST) -> Iterator[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """The functions a module can bind as its own attributes.
+
+    Registration resolves a declaration with getattr on the imported module, so
+    a method or a function nested inside another is not something it can reach.
+    A def and a class open a new scope and stop the descent. Everything else is
+    followed, an if, a try, a with, a loop and a match case alike, and naming
+    none of them individually is the point: a def only appears in a statement
+    list, so descending through expressions cannot turn up a false one, and a
+    statement this misses is a declaration dropped with nothing raised.
+    """
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield child
+        elif not isinstance(child, ast.ClassDef):
+            yield from _module_scope_functions(child)
+
+
 def get_tools_from_ast(tree: ast.AST) -> list[str]:
     """
     Retrieve tools from Python source code.
     """
-    tools = []
-    for node in ast.walk(tree):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            tool_name = get_function_name_if_decorated(node)
-            if tool_name:
-                tools.append(tool_name)
-    return tools
+    # One name is one module attribute however many times it is written, so a
+    # module defining the same tool in both arms of an if or a try/except
+    # contributes it once.
+    return list(
+        dict.fromkeys(
+            name
+            for node in _module_scope_functions(tree)
+            if (name := get_function_name_if_decorated(node))
+        )
+    )

--- a/libs/tests/core/test_catalog.py
+++ b/libs/tests/core/test_catalog.py
@@ -1,3 +1,4 @@
+from types import ModuleType
 from typing import Annotated, Union
 from unittest.mock import MagicMock, patch
 
@@ -238,6 +239,30 @@ def test_add_toolkit_type_error():
         # Assert that ToolDefinitionError is raised
         with pytest.raises(ToolDefinitionError):
             catalog.add_toolkit(mock_toolkit)
+
+
+def test_add_toolkit_skips_a_tool_the_module_does_not_define(caplog):
+    """Discovery reads the source, so a tool behind a false guard is found there and absent here."""
+    catalog = ToolCatalog()
+    mock_toolkit = Toolkit(
+        name="mock_toolkit",
+        description="A mock toolkit",
+        version="0.0.1",
+        package_name="mock_toolkit",
+    )
+    mock_toolkit.tools = {"mock_module": ["unreachable", "sample_tool"]}
+
+    # A real module object, because a MagicMock answers every getattr and would
+    # never let the missing-attribute path run.
+    module = ModuleType("mock_module")
+    module.__file__ = "mock_module.py"
+    module.sample_tool = sample_tool  # type: ignore[attr-defined]
+
+    with patch("arcade_core.catalog.import_module", return_value=module):
+        catalog.add_toolkit(mock_toolkit)
+
+    assert len(catalog) == 1, "one unreachable tool must not take the toolkit's other tools with it"
+    assert "mock_module.unreachable" in caplog.text
 
 
 def test_add_toolkit_import_module_error():

--- a/libs/tests/core/test_parse.py
+++ b/libs/tests/core/test_parse.py
@@ -49,3 +49,75 @@ def test_get_function_name_if_decorated(source, expected_tools):
     tree = ast.parse(source)
     tools = get_tools_from_ast(tree)
     assert tools == expected_tools
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(
+            "class Helpers:\n    @tool\n    def a(self): ...",
+            id="a method is an attribute of the class",
+        ),
+        pytest.param(
+            "def outer():\n    @tool\n    def a(): ...\n    return a",
+            id="a nested function is a local of its enclosing one",
+        ),
+        pytest.param(
+            "async def outer():\n    @tool\n    def a(): ...",
+            id="the same inside an async def",
+        ),
+        pytest.param(
+            "def outer():\n    class Inner:\n        @tool\n        def a(self): ...",
+            id="a class inside a function is doubly out of reach",
+        ),
+    ],
+)
+def test_a_tool_the_module_cannot_bind_is_not_discovered(source):
+    """Registration reaches a tool with getattr on the module, and nothing else."""
+    assert get_tools_from_ast(ast.parse(source)) == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param("if True:\n    @tool\n    def a(): ...", id="if"),
+        pytest.param("if False:\n    pass\nelse:\n    @tool\n    def a(): ...", id="else"),
+        pytest.param("try:\n    @tool\n    def a(): ...\nexcept ImportError:\n    pass", id="try"),
+        pytest.param(
+            "try:\n    pass\nexcept ImportError:\n    @tool\n    def a(): ...",
+            id="except",
+        ),
+        pytest.param("try:\n    pass\nfinally:\n    @tool\n    def a(): ...", id="finally"),
+        pytest.param("for _ in range(1):\n    @tool\n    def a(): ...", id="for"),
+        pytest.param("with open(__file__):\n    @tool\n    def a(): ...", id="with"),
+        pytest.param("match 1:\n    case 1:\n        @tool\n        def a(): ...", id="match case"),
+    ],
+)
+def test_a_tool_guarded_by_a_module_level_block_is_discovered(source):
+    """These keep module scope, so the name really can become an attribute."""
+    assert get_tools_from_ast(ast.parse(source)) == ["a"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(
+            "if True:\n    @tool\n    def a(): ...\nelse:\n    @tool\n    def a(): ...",
+            id="both arms of an if",
+        ),
+        pytest.param(
+            "try:\n    @tool\n    def a(): ...\nexcept ImportError:\n    @tool\n    def a(): ...",
+            id="both arms of a try",
+        ),
+    ],
+)
+def test_a_name_written_in_two_branches_is_one_tool(source):
+    """Only one arm binds at import, so counting both would register the same function twice."""
+    assert get_tools_from_ast(ast.parse(source)) == ["a"]
+
+
+def test_discovery_keeps_source_order():
+    """The catalog is built by walking this list, so the order it reports is the order it sees."""
+    source = "@tool\ndef z(): ...\n\n@tool\ndef a(): ...\n\n@tool\ndef m(): ..."
+
+    assert get_tools_from_ast(ast.parse(source)) == ["z", "a", "m"]


### PR DESCRIPTION
## At a glance

- One `@tool` on a class method, or under a `__main__` guard, currently takes **every tool in that toolkit** offline.
- Discovery now collects only what a module can bind, and registration skips a name the module does not define instead of failing the whole load.
- 4 files, +137 −8. 19 parse tests and 1 catalog test, each verified to fail without its fix.
- Targets `main`. Not part of the worker-resources stack.

## The failure

`get_tools_from_ast` used `ast.walk`, which visits every function node in a file: methods on classes, functions nested inside other functions, anything under a guard. `add_toolkit` then resolved each collected name with `getattr` on the imported module, and the `AttributeError` became a fatal `ToolDefinitionError`.

Reproduced on `main` before fixing. A package with a working `add` tool and one `@tool` on a class method in a second module:

```
discovered tools: {'arcade_demo.helper': ['internal'], 'arcade_demo.good': ['add']}
RESULT: ToolDefinitionError -> Could not import tool internal in module arcade_demo.helper
```

The toolkit loads zero tools. `add` is fine and never gets a chance.

After:

```
WARNING  arcade_demo.guarded.demo is decorated with @tool but the module does not define it. Skipping it.
RESULT: loaded 1 tool(s): ['Add']
```

## Two changes, because scope alone does not settle it

**Discovery.** `_module_scope_functions` replaces the walk. It stops at a `def` and a `class`, the two that open a new scope, and follows everything else. Naming none of the containers individually is the point: a `def` appears only in a statement list, so descending through expressions cannot turn up a false one, and no statement can be missed by omission. An earlier version of this helper enumerated field names and silently missed `ast.Match.cases`.

Names are also deduplicated in source order. A module defining the same tool in both arms of an `if` or a `try`/`except` binds it once, and counting it twice would register the same function twice.

**Registration.** A `@tool` under `if __name__ == "__main__"` is module scope in the source and absent after an import, so scope cannot catch it. `add_toolkit` now skips a name the module does not define and logs it.

That is a behavior change worth arguing with, so here is the argument. A tool that is absent is one tool missing, named in the log with its module. A toolkit that will not load is all of them, plus an error that points at the wrong thing. The second is what this PR removes.

## Relationship to #920

#920 introduces the resource authoring path and had the identical defect on it, fixed in `37c94d85`. `_module_scope_functions` here is copied verbatim from there, so whichever of the two merges second will conflict on the duplicate definition and resolving it is taking either copy.

The registration halves differ in wording only; both skip and log.

## Verification

`libs/tests` 3749 passed, 1 skipped. `mypy` clean on `arcade-core`. `ruff format --check` and `ruff check` clean.

Each new test was run against the code it replaces:

- reverting the walk fails `test_a_tool_guarded_by_a_module_level_block_is_discovered`
- removing the dedup fails `test_a_name_written_in_two_branches_is_one_tool`
- reverting the `getattr` default fails `test_add_toolkit_skips_a_tool_the_module_does_not_define`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tool names are discovered and makes registration tolerate missing attributes, so some previously fatal misconfigurations become silent skips with warnings.
> 
> **Overview**
> Fixes toolkit loads failing entirely when one unreachable `@tool` (e.g. on a class method) was picked up by AST discovery but could not be resolved with `getattr` on the imported module.
> 
> **Discovery** (`parse.py`) stops using `ast.walk` and instead walks only **module-scope** function definitions via `_module_scope_functions`, still finding tools inside `if`/`try`/`match` blocks but ignoring nested defs and class methods. Duplicate names across branches are deduplicated in source order.
> 
> **Registration** (`catalog.py`) uses `getattr(..., None)` and **skips** tools the module does not define at import time, logging a warning instead of raising `ToolDefinitionError` and blocking the rest of the toolkit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f007f893afa34860a24b4f6abcfab21b4575b1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->