### PR TITLE
[PLT-3225] feat: add protected API authorization outcome

### DIFF
--- a/libs/arcade-core/arcade_core/executor.py
+++ b/libs/arcade-core/arcade_core/executor.py
@@ -44,6 +44,8 @@ class ToolExecutor:
                 )
             )
 
+        context.protected_api_outcome = None
+
         try:
             # serialize the input model
             inputs = await ToolExecutor._serialize_input(input_model, **kwargs)
@@ -64,12 +66,11 @@ class ToolExecutor:
             # serialize the output model
             output = await ToolExecutor._serialize_output(output_model, results)
 
-            # return the output
-            return output_factory.success(data=output, logs=tool_call_logs)
+            tool_output = output_factory.success(data=output, logs=tool_call_logs)
 
         except ToolRuntimeError as e:
             e.with_context(func.__name__)
-            return output_factory.fail(
+            tool_output = output_factory.fail(
                 message=e.message,
                 developer_message=e.developer_message,
                 stacktrace=e.stacktrace(),
@@ -83,11 +84,14 @@ class ToolExecutor:
 
         # if we get here we're in trouble
         except Exception as e:
-            return output_factory.fail(
+            tool_output = output_factory.fail(
                 message=f"Error in execution of '{func.__name__}'",
                 developer_message=str(e),
                 stacktrace=traceback.format_exc(),
             )
+
+        tool_output.protected_api_outcome = context.protected_api_outcome
+        return tool_output
 
     @staticmethod
     async def _serialize_input(input_model: type[BaseModel], **kwargs: Any) -> BaseModel:

--- a/libs/arcade-core/arcade_core/protected_api.py
+++ b/libs/arcade-core/arcade_core/protected_api.py
@@ -1,0 +1,78 @@
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Generic, TypeVar
+
+import httpx
+
+from arcade_core.schema import ToolContext
+
+T = TypeVar("T")
+
+
+class ProtectedAPIOutcome(str, Enum):
+    """Private authorization outcome for one protected API request."""
+
+    ACCEPTED = "accepted"
+    AUTHORIZATION_DENIED = "authorization_denied"
+    UNAVAILABLE = "unavailable"
+
+
+@dataclass(frozen=True)
+class ProtectedAPIResult(Generic[T]):
+    """A protected API value paired with its private authorization outcome."""
+
+    value: T | None
+    outcome: ProtectedAPIOutcome
+
+
+async def call_protected_api(
+    context: ToolContext,
+    method: str,
+    url: str,
+    *,
+    timeout: float,
+    headers: Mapping[str, str] | None = None,
+    params: Mapping[str, str] | None = None,
+    json_body: Any = None,
+) -> ProtectedAPIResult[Any]:
+    """Make one authenticated request and return a fixed private outcome.
+
+    The adapter never retries and never returns authorization or transport
+    response bodies for denied or unavailable requests.
+    """
+
+    token = context.get_auth_token_or_empty()
+    if not token:
+        raise ValueError("protected API calls require an authorization token")
+
+    request_headers = dict(headers or {})
+    if any(key.lower() == "authorization" for key in request_headers):
+        raise ValueError("protected API authorization is supplied by the tool context")
+    request_headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        async with httpx.AsyncClient(timeout=timeout, follow_redirects=False) as client:
+            response = await client.request(
+                method,
+                url,
+                headers=request_headers,
+                params=params,
+                json=json_body,
+            )
+    except (httpx.RequestError, httpx.InvalidURL):
+        return ProtectedAPIResult(value=None, outcome=ProtectedAPIOutcome.UNAVAILABLE)
+
+    if response.status_code in (401, 403):
+        return ProtectedAPIResult(
+            value=None,
+            outcome=ProtectedAPIOutcome.AUTHORIZATION_DENIED,
+        )
+    if not 200 <= response.status_code < 300:
+        return ProtectedAPIResult(value=None, outcome=ProtectedAPIOutcome.UNAVAILABLE)
+
+    try:
+        value = response.json()
+    except ValueError:
+        value = response.text
+    return ProtectedAPIResult(value=value, outcome=ProtectedAPIOutcome.ACCEPTED)

--- a/libs/arcade-core/arcade_core/protected_api.py
+++ b/libs/arcade-core/arcade_core/protected_api.py
@@ -9,6 +9,8 @@ from arcade_core.schema import ToolContext
 
 T = TypeVar("T")
 
+PROTECTED_API_METADATA_NAMESPACE = "arcade.token_exchange.v1"
+
 
 class ProtectedAPIOutcome(str, Enum):
     """Private authorization outcome for one protected API request."""
@@ -33,6 +35,22 @@ def _result(
 ) -> ProtectedAPIResult[T]:
     context.protected_api_outcome = outcome.value
     return ProtectedAPIResult(value=value, outcome=outcome)
+
+
+def build_protected_api_metadata(outcome: str | None) -> dict[str, dict[str, str]] | None:
+    """Build the versioned wire metadata for one allowlisted outcome."""
+
+    if outcome is None:
+        return None
+    try:
+        protected_api_outcome = ProtectedAPIOutcome(outcome)
+    except ValueError:
+        return None
+    return {
+        PROTECTED_API_METADATA_NAMESPACE: {
+            "protected_api_outcome": protected_api_outcome.value,
+        }
+    }
 
 
 async def call_protected_api(

--- a/libs/arcade-core/arcade_core/protected_api.py
+++ b/libs/arcade-core/arcade_core/protected_api.py
@@ -26,6 +26,15 @@ class ProtectedAPIResult(Generic[T]):
     outcome: ProtectedAPIOutcome
 
 
+def _result(
+    context: ToolContext,
+    value: T | None,
+    outcome: ProtectedAPIOutcome,
+) -> ProtectedAPIResult[T]:
+    context.protected_api_outcome = outcome.value
+    return ProtectedAPIResult(value=value, outcome=outcome)
+
+
 async def call_protected_api(
     context: ToolContext,
     method: str,
@@ -61,18 +70,15 @@ async def call_protected_api(
                 json=json_body,
             )
     except (httpx.RequestError, httpx.InvalidURL):
-        return ProtectedAPIResult(value=None, outcome=ProtectedAPIOutcome.UNAVAILABLE)
+        return _result(context, None, ProtectedAPIOutcome.UNAVAILABLE)
 
     if response.status_code in (401, 403):
-        return ProtectedAPIResult(
-            value=None,
-            outcome=ProtectedAPIOutcome.AUTHORIZATION_DENIED,
-        )
+        return _result(context, None, ProtectedAPIOutcome.AUTHORIZATION_DENIED)
     if not 200 <= response.status_code < 300:
-        return ProtectedAPIResult(value=None, outcome=ProtectedAPIOutcome.UNAVAILABLE)
+        return _result(context, None, ProtectedAPIOutcome.UNAVAILABLE)
 
     try:
         value = response.json()
     except ValueError:
         value = response.text
-    return ProtectedAPIResult(value=value, outcome=ProtectedAPIOutcome.ACCEPTED)
+    return _result(context, value, ProtectedAPIOutcome.ACCEPTED)

--- a/libs/arcade-core/arcade_core/schema.py
+++ b/libs/arcade-core/arcade_core/schema.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal, Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_serializer
 
 from arcade_core.errors import ErrorKind
 from arcade_core.metadata import ToolMetadata
@@ -677,3 +677,13 @@ class ToolCallResponse(BaseModel):
     """Whether the tool execution was successful."""
     output: ToolCallOutput | None = None
     """The output of the tool invocation."""
+    meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+    """Private transport metadata for the Engine."""
+
+    @model_serializer(mode="wrap")
+    def _omit_empty_meta(self, handler: Any) -> dict[str, Any]:
+        result: dict[str, Any] = handler(self)
+        if self.meta is None:
+            result.pop("meta", None)
+            result.pop("_meta", None)
+        return result

--- a/libs/arcade-core/arcade_core/schema.py
+++ b/libs/arcade-core/arcade_core/schema.py
@@ -421,6 +421,9 @@ class ToolContext(BaseModel):
     user_id: str | None = None
     """The user ID for the tool invocation (if any)."""
 
+    protected_api_outcome: str | None = Field(default=None, exclude=True, repr=False)
+    """Private protected-API outcome recorded during this invocation."""
+
     model_config = {"arbitrary_types_allowed": True}
 
     def set_secret(self, key: str, value: str) -> None:
@@ -645,6 +648,9 @@ class ToolCallOutput(BaseModel):
     """The error that occurred during the tool invocation."""
     requires_authorization: ToolCallRequiresAuthorization | None = None
     """The authorization requirements for the tool invocation."""
+
+    protected_api_outcome: str | None = Field(default=None, exclude=True, repr=False)
+    """Private protected-API outcome for transport projection."""
 
     model_config = {
         "json_schema_extra": {

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.11.0"
+version = "4.12.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-mcp-server/arcade_mcp_server/decorators.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/decorators.py
@@ -32,6 +32,7 @@ def tool(
     requires_metadata: list[str] | None = None,
     adapters: list[ErrorAdapter] | None = None,
     metadata: ToolMetadata | None = None,
+    protected_api: bool = False,
     execution: ToolExecution | None = None,
 ) -> Callable:
     """MCP-aware ``@tool`` decorator.
@@ -54,6 +55,7 @@ def tool(
             requires_metadata=requires_metadata,
             adapters=adapters,
             metadata=metadata,
+            protected_api=protected_api,
         )
         # Write on the error-handler-wrapped callable arcade-tdk returns.
         # Both read sites (``server.py`` for taskSupport policy and

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -28,6 +28,7 @@ from arcade_core.errors import ErrorKind, ToolInputError
 from arcade_core.executor import ToolExecutor
 from arcade_core.log_extras import build_tool_error_log_extra, build_tool_error_span_attributes
 from arcade_core.network.org_transport import build_org_scoped_async_http_client
+from arcade_core.protected_api import build_protected_api_metadata
 from arcade_core.schema import ToolAuthorizationContext, ToolCallError, ToolContext
 from arcade_core.schema import ToolAuthRequirement as CoreToolAuthRequirement
 from arcadepy import ArcadeError, AsyncArcade
@@ -1574,6 +1575,7 @@ class MCPServer:
                     mctx.set_tool_context(saved_tool_context)
 
             # Convert result
+            protected_api_meta = build_protected_api_metadata(result.protected_api_outcome)
             if result.value is not None:
                 content = convert_to_mcp_content(result.value)
 
@@ -1587,6 +1589,7 @@ class MCPServer:
                         content=content,
                         structuredContent=structured_content,
                         isError=False,
+                        **({"_meta": protected_api_meta} if protected_api_meta else {}),
                     ),
                 )
             else:
@@ -1632,22 +1635,16 @@ class MCPServer:
                 # no structured error to surface. ``**{"_meta": ...}`` matches the
                 # alias convention used by CreateTaskResult above and works under
                 # ``Result.model_config.populate_by_name=True``.
-                error_meta: dict[str, Any] | None = (
-                    {"arcade": _build_arcade_error_meta(error)} if error is not None else None
-                )
-                call_tool_result = (
-                    CallToolResult(
-                        content=content,
-                        structuredContent=None,
-                        isError=True,
-                        **{"_meta": error_meta},
-                    )
-                    if error_meta is not None
-                    else CallToolResult(
-                        content=content,
-                        structuredContent=None,
-                        isError=True,
-                    )
+                response_meta: dict[str, Any] = {}
+                if error is not None:
+                    response_meta["arcade"] = _build_arcade_error_meta(error)
+                if protected_api_meta:
+                    response_meta.update(protected_api_meta)
+                call_tool_result = CallToolResult(
+                    content=content,
+                    structuredContent=None,
+                    isError=True,
+                    **({"_meta": response_meta} if response_meta else {}),
                 )
                 return JSONRPCResponse(id=message.id, result=call_tool_result)
         except NotFoundError:

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.26.0"
+version = "1.27.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,9 +21,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.11.0,<5.0.0",
+    "arcade-core>=4.12.0,<5.0.0",
     "arcade-serve>=3.4.0,<4.0.0",
-    "arcade-tdk>=3.10.1,<4.0.0",
+    "arcade-tdk>=3.11.0,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",
     "fastapi>=0.100.0",

--- a/libs/arcade-serve/arcade_serve/core/base.py
+++ b/libs/arcade-serve/arcade_serve/core/base.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, ClassVar
 from arcade_core.catalog import ToolCatalog, Toolkit
 from arcade_core.executor import ToolExecutor
 from arcade_core.log_extras import build_tool_error_log_extra, build_tool_error_span_attributes
+from arcade_core.protected_api import build_protected_api_metadata
 from arcade_core.schema import (
     ToolCallRequest,
     ToolCallResponse,
@@ -193,6 +194,7 @@ class BaseWorker(Worker):
             finished_at=datetime.now().isoformat(),
             success=not output.error,
             output=output,
+            **{"_meta": build_protected_api_metadata(output.protected_api_outcome)},
         )
 
     def health_check(self) -> dict[str, Any]:

--- a/libs/arcade-serve/pyproject.toml
+++ b/libs/arcade-serve/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-serve"
-version = "3.4.2"
+version = "3.5.0"
 description = "Arcade Serve - Serving infrastructure for Arcade tools and workers"
 readme = "README.md"
 license = {text = "MIT"}
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.9.0,<5.0.0",
+    "arcade-core>=4.12.0,<5.0.0",
     "fastapi>=0.115.3",
     "uvicorn>=0.30.0",
     "watchfiles>=1.0.5",

--- a/libs/arcade-tdk/arcade_tdk/protected_api.py
+++ b/libs/arcade-tdk/arcade_tdk/protected_api.py
@@ -1,0 +1,11 @@
+from arcade_core.protected_api import (
+    ProtectedAPIOutcome,
+    ProtectedAPIResult,
+    call_protected_api,
+)
+
+__all__ = [
+    "ProtectedAPIOutcome",
+    "ProtectedAPIResult",
+    "call_protected_api",
+]

--- a/libs/arcade-tdk/arcade_tdk/tool.py
+++ b/libs/arcade-tdk/arcade_tdk/tool.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Callable, TypeVar
 
 from arcade_core.metadata import ToolMetadata
+from arcade_core.protected_api import PROTECTED_API_METADATA_NAMESPACE
 
 from arcade_tdk.auth import ToolAuthorization
 from arcade_tdk.error_adapters import ErrorAdapter
@@ -139,17 +140,25 @@ def tool(
     requires_metadata: list[str] | None = None,
     adapters: list[ErrorAdapter] | None = None,
     metadata: ToolMetadata | None = None,
+    protected_api: bool = False,
 ) -> Callable:
     def decorator(func: Callable) -> Callable:
         func_name = str(getattr(func, "__name__", None))
         tool_name = name or snake_to_pascal_case(func_name)
+        tool_metadata = metadata
+        if protected_api:
+            extras = dict(metadata.extras or {}) if metadata else {}
+            extras[PROTECTED_API_METADATA_NAMESPACE] = True
+            tool_metadata = (metadata or ToolMetadata()).model_copy(
+                update={"extras": extras}, deep=True
+            )
 
         func.__tool_name__ = tool_name  # type: ignore[attr-defined]
         func.__tool_description__ = desc or inspect.cleandoc(func.__doc__ or "")  # type: ignore[attr-defined]
         func.__tool_requires_auth__ = requires_auth  # type: ignore[attr-defined]
         func.__tool_requires_secrets__ = requires_secrets  # type: ignore[attr-defined]
         func.__tool_requires_metadata__ = requires_metadata  # type: ignore[attr-defined]
-        func.__tool_metadata__ = metadata  # type: ignore[attr-defined]
+        func.__tool_metadata__ = tool_metadata  # type: ignore[attr-defined]
 
         adapter_chain = _build_adapter_chain(adapters, requires_auth)
 

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "3.10.1"
+version = "3.11.0"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = { text = "MIT" }
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
-dependencies = ["arcade-core>=4.11.0,<5.0.0", "pydantic>=2.7.0"]
+dependencies = ["arcade-core>=4.12.0,<5.0.0", "pydantic>=2.7.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/libs/tests/arcade_mcp_server/test_server.py
+++ b/libs/tests/arcade_mcp_server/test_server.py
@@ -304,6 +304,43 @@ class TestMCPServer:
         assert "Echo: Hello" in response.result.structuredContent["result"]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("outcome", "value"),
+        [
+            ("accepted", {"message": "ok"}),
+            ("authorization_denied", None),
+            ("unavailable", None),
+        ],
+    )
+    async def test_handle_call_tool_returns_private_protected_api_outcome(
+        self,
+        mcp_server,
+        outcome,
+        value,
+    ):
+        message = CallToolRequest(
+            jsonrpc="2.0",
+            id=3,
+            method="tools/call",
+            params={"name": "TestToolkit.test_tool", "arguments": {"text": "Hello"}},
+        )
+
+        with patch(
+            "arcade_mcp_server.server.ToolExecutor.run",
+            new=AsyncMock(
+                return_value=ToolCallOutput(value=value, protected_api_outcome=outcome)
+            ),
+        ):
+            response = await mcp_server._handle_call_tool(message)
+
+        assert isinstance(response, JSONRPCResponse)
+        assert isinstance(response.result, CallToolResult)
+        assert response.result.meta == {
+            "arcade.token_exchange.v1": {"protected_api_outcome": outcome}
+        }
+        assert outcome not in str(response.result.content)
+
+    @pytest.mark.asyncio
     async def test_handle_call_tool_with_requires_auth(self, mcp_server):
         """Test tool call request handling with authorization."""
 

--- a/libs/tests/arcade_mcp_server/test_tool_wrapper.py
+++ b/libs/tests/arcade_mcp_server/test_tool_wrapper.py
@@ -13,12 +13,11 @@ import inspect
 
 import pytest
 from arcade_core.metadata import ToolMetadata
+from arcade_mcp_server.decorators import tool
+from arcade_mcp_server.types import ToolExecution
 from arcade_tdk import tool as _arcade_tdk_tool
 from arcade_tdk.auth import OAuth2
 from arcade_tdk.errors import ToolRuntimeError
-
-from arcade_mcp_server.decorators import tool
-from arcade_mcp_server.types import ToolExecution
 
 
 class TestBareAndParameterizedForms:
@@ -162,6 +161,15 @@ class TestDeprecatedForwarding:
             return "x"
 
         assert my_old_tool.__tool_deprecation_message__ == "use my_new_tool instead"
+
+
+class TestProtectedAPICapabilityForwarding:
+    def test_protected_api_declaration_is_forwarded(self):
+        @tool(protected_api=True)
+        def my_tool() -> str:
+            return "ok"
+
+        assert my_tool.__tool_metadata__.extras == {"arcade.token_exchange.v1": True}
 
 
 class TestSignatureMirror:

--- a/libs/tests/core/test_executor.py
+++ b/libs/tests/core/test_executor.py
@@ -117,7 +117,7 @@ def dict_output_tool() -> Annotated[dict, "Returns a plain dict"]:
 @tool
 def protected_api_output_tool(context: ToolContext) -> Annotated[str, "Protected API output"]:
     """Return a value with a private protected API outcome."""
-    setattr(context, "protected_api_outcome", "accepted")
+    context.protected_api_outcome = "accepted"
     return "ok"
 
 

--- a/libs/tests/core/test_executor.py
+++ b/libs/tests/core/test_executor.py
@@ -114,6 +114,13 @@ def dict_output_tool() -> Annotated[dict, "Returns a plain dict"]:
     return {"key": "value", "number": 42, "nested": {"inner": "data"}}
 
 
+@tool
+def protected_api_output_tool(context: ToolContext) -> Annotated[str, "Protected API output"]:
+    """Return a value with a private protected API outcome."""
+    setattr(context, "protected_api_outcome", "accepted")
+    return "ok"
+
+
 # ---- Test Driver ----
 tools = [
     simple_tool,
@@ -129,6 +136,7 @@ tools = [
     typeddict_output_tool,
     list_typeddict_output_tool,
     dict_output_tool,
+    protected_api_output_tool,
 ]
 catalog = ToolCatalog()
 for tool_func in tools:
@@ -326,6 +334,24 @@ async def test_tool_executor(tool_func, inputs, expected_output):
     )
 
     check_output(output, expected_output)
+
+
+@pytest.mark.asyncio
+async def test_tool_executor_preserves_private_protected_api_outcome() -> None:
+    tool_definition = catalog.find_tool_by_func(protected_api_output_tool)
+    full_tool = catalog.get_tool(tool_definition.get_fully_qualified_name())
+
+    output = await ToolExecutor.run(
+        func=protected_api_output_tool,
+        definition=tool_definition,
+        input_model=full_tool.input_model,
+        output_model=full_tool.output_model,
+        context=ToolContext(),
+    )
+
+    assert output.value == "ok"
+    assert output.protected_api_outcome == "accepted"
+    assert "protected_api" not in output.model_dump_json()
 
 
 def check_output_error(output_error: ToolCallError, expected_error: ToolCallError):

--- a/libs/tests/tool/test_protected_api.py
+++ b/libs/tests/tool/test_protected_api.py
@@ -5,7 +5,6 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 import pytest
-
 from arcade_core.schema import ToolAuthorizationContext, ToolContext
 from arcade_tdk.protected_api import ProtectedAPIOutcome, call_protected_api
 
@@ -26,7 +25,7 @@ def protected_api_server() -> Generator[tuple[str, list[dict[str, Any]]], None, 
             self.end_headers()
             self.wfile.write(json.dumps({"message": "accepted"}).encode())
 
-        def log_message(self, format: str, *args: Any) -> None:
+        def log_message(self, format_string: str, *args: Any) -> None:
             pass
 
     server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
@@ -57,9 +56,8 @@ async def test_call_protected_api_makes_one_authenticated_attempt(
     expected_value: Any,
 ) -> None:
     base_url, requests = protected_api_server
-    context = ToolContext(
-        authorization=ToolAuthorizationContext(token="target-token-sentinel")
-    )
+    sentinel = "target-token-sentinel"
+    context = ToolContext(authorization=ToolAuthorizationContext(token=sentinel))
 
     result = await call_protected_api(
         context,

--- a/libs/tests/tool/test_protected_api.py
+++ b/libs/tests/tool/test_protected_api.py
@@ -1,0 +1,78 @@
+import json
+import threading
+from collections.abc import Generator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+
+from arcade_core.schema import ToolAuthorizationContext, ToolContext
+from arcade_tdk.protected_api import ProtectedAPIOutcome, call_protected_api
+
+
+@pytest.fixture
+def protected_api_server() -> Generator[tuple[str, list[dict[str, Any]]], None, None]:
+    requests: list[dict[str, Any]] = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:
+            requests.append({
+                "authorization": self.headers.get("Authorization"),
+                "path": self.path,
+            })
+            status_code = int(self.path.removeprefix("/"))
+            self.send_response(status_code)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"message": "accepted"}).encode())
+
+        def log_message(self, format: str, *args: Any) -> None:
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host, port = server.server_address
+        yield f"http://{host}:{port}", requests
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status_code", "expected_outcome", "expected_value"),
+    [
+        (200, ProtectedAPIOutcome.ACCEPTED, {"message": "accepted"}),
+        (403, ProtectedAPIOutcome.AUTHORIZATION_DENIED, None),
+        (503, ProtectedAPIOutcome.UNAVAILABLE, None),
+    ],
+)
+async def test_call_protected_api_makes_one_authenticated_attempt(
+    protected_api_server: tuple[str, list[dict[str, Any]]],
+    status_code: int,
+    expected_outcome: ProtectedAPIOutcome,
+    expected_value: Any,
+) -> None:
+    base_url, requests = protected_api_server
+    context = ToolContext(
+        authorization=ToolAuthorizationContext(token="target-token-sentinel")
+    )
+
+    result = await call_protected_api(
+        context,
+        "POST",
+        f"{base_url}/{status_code}",
+        timeout=1,
+    )
+
+    assert result.outcome is expected_outcome
+    assert result.value == expected_value
+    assert requests == [
+        {
+            "authorization": "Bearer target-token-sentinel",
+            "path": f"/{status_code}",
+        }
+    ]

--- a/libs/tests/tool/test_tool_metadata.py
+++ b/libs/tests/tool/test_tool_metadata.py
@@ -327,6 +327,24 @@ class TestToolDecoratorWithMetadata:
         assert hasattr(my_tool, "__tool_metadata__")
         assert my_tool.__tool_metadata__.classification.service_domains == [ServiceDomain.MESSAGING]
 
+    def test_protected_api_declaration_adds_capability_without_mutating_metadata(self):
+        metadata = ToolMetadata(extras={"owner": "payments"})
+
+        @tool(desc="Call a protected API", metadata=metadata, protected_api=True)
+        def protected_tool() -> str:
+            return "ok"
+
+        definition = ToolCatalog.create_tool_definition(
+            protected_tool, toolkit_name="TestToolkit", toolkit_version="1.0.0"
+        )
+
+        assert definition.metadata is not None
+        assert definition.metadata.extras == {
+            "owner": "payments",
+            "arcade.token_exchange.v1": True,
+        }
+        assert metadata.extras == {"owner": "payments"}
+
     def test_decorator_accepts_sales_intelligence_domain(self):
         """SALES_INTELLIGENCE classifies sales-intelligence / prospecting services (e.g. Apollo)."""
         assert ServiceDomain.SALES_INTELLIGENCE.value == "sales_intelligence"

--- a/libs/tests/worker/test_worker_fastapi.py
+++ b/libs/tests/worker/test_worker_fastapi.py
@@ -28,6 +28,15 @@ def error_throwing_tool(
     raise ValueError("Test execution error")
 
 
+@tool()
+def protected_api_tool_fastapi(
+    context: ToolContext,
+) -> Annotated[dict[str, str], "Protected API response"]:
+    """Return an accepted protected API result."""
+    context.protected_api_outcome = "accepted"
+    return {"message": "ok"}
+
+
 @pytest.fixture
 def test_app():
     return FastAPI()
@@ -151,6 +160,26 @@ def test_call_tool_route_no_auth_worker(client_no_auth, call_tool_payload):
     result = response.json()
     assert result["success"] is True
     assert result["output"]["value"] == "hello-123"
+
+
+def test_call_tool_route_returns_private_protected_api_outcome() -> None:
+    app = FastAPI()
+    worker = FastAPIWorker(app=app, disable_auth=True)
+    worker.register_tool(protected_api_tool_fastapi, toolkit_name="protected_api_kit")
+    client = TestClient(app)
+    request = ToolCallRequest(
+        execution_id="protected-api-exec",
+        tool=ToolReference(toolkit="ProtectedApiKit", name="ProtectedApiToolFastapi"),
+    )
+
+    response = client.post("/worker/tools/invoke", json=request.model_dump())
+
+    assert response.status_code == 200
+    result = response.json()
+    assert result["_meta"] == {
+        "arcade.token_exchange.v1": {"protected_api_outcome": "accepted"}
+    }
+    assert "protected_api" not in str(result["output"])
 
 
 def test_call_tool_route_tool_not_found(client_no_auth, call_tool_payload):

--- a/libs/tests/worker/test_worker_fastapi.py
+++ b/libs/tests/worker/test_worker_fastapi.py
@@ -31,9 +31,10 @@ def error_throwing_tool(
 @tool()
 def protected_api_tool_fastapi(
     context: ToolContext,
+    outcome: Annotated[str, "Protected API outcome"],
 ) -> Annotated[dict[str, str], "Protected API response"]:
-    """Return an accepted protected API result."""
-    context.protected_api_outcome = "accepted"
+    """Return a protected API result."""
+    context.protected_api_outcome = outcome
     return {"message": "ok"}
 
 
@@ -163,7 +164,8 @@ def test_call_tool_route_no_auth_worker(client_no_auth, call_tool_payload):
     assert "_meta" not in result
 
 
-def test_call_tool_route_returns_private_protected_api_outcome() -> None:
+@pytest.mark.parametrize("outcome", ["accepted", "authorization_denied", "unavailable"])
+def test_call_tool_route_returns_private_protected_api_outcome(outcome: str) -> None:
     app = FastAPI()
     worker = FastAPIWorker(app=app, disable_auth=True)
     worker.register_tool(protected_api_tool_fastapi, toolkit_name="protected_api_kit")
@@ -171,6 +173,7 @@ def test_call_tool_route_returns_private_protected_api_outcome() -> None:
     request = ToolCallRequest(
         execution_id="protected-api-exec",
         tool=ToolReference(toolkit="ProtectedApiKit", name="ProtectedApiToolFastapi"),
+        inputs={"outcome": outcome},
     )
 
     response = client.post("/worker/tools/invoke", json=request.model_dump())
@@ -178,7 +181,7 @@ def test_call_tool_route_returns_private_protected_api_outcome() -> None:
     assert response.status_code == 200
     result = response.json()
     assert result["_meta"] == {
-        "arcade.token_exchange.v1": {"protected_api_outcome": "accepted"}
+        "arcade.token_exchange.v1": {"protected_api_outcome": outcome}
     }
     assert "protected_api" not in str(result["output"])
 

--- a/libs/tests/worker/test_worker_fastapi.py
+++ b/libs/tests/worker/test_worker_fastapi.py
@@ -160,6 +160,7 @@ def test_call_tool_route_no_auth_worker(client_no_auth, call_tool_payload):
     result = response.json()
     assert result["success"] is True
     assert result["output"]["value"] == "hello-123"
+    assert "_meta" not in result
 
 
 def test_call_tool_route_returns_private_protected_api_outcome() -> None:


### PR DESCRIPTION
## Why

Companion to ArcadeAI/monorepo#3731. Enterprise token exchange needs a private, execution-boundary contract for giving a trusted customer-managed Worker the exchanged target token and returning a fixed protected-API outcome without exposing credential material in public tool data.

## What

- Adds a one-attempt protected API adapter.
- Adds the protected_api tool capability declaration.
- Carries the private authorization outcome through HTTP and MCP Worker transports.
- Keeps the outcome contract fixed to status, reason, and request-count evidence.
- Versions the coordinated core, TDK, serve, and MCP server packages.

## Verification

The coordinated branch test run completed with 3,745 tests passed and one skipped; changed-package formatting and type checks passed.

## Review ask

@wdawson, please review this together with ArcadeAI/monorepo#3731, especially the credential boundary and the decision to keep the target token in the existing private authorization context.