### PR TITLE
feat(arcade-mcp-server): add handshake-free server discovery

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -78,8 +78,10 @@ from arcade_mcp_server.types import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
     INVALID_REQUEST,
+    LATEST_PROTOCOL_VERSION,
     METHOD_NOT_FOUND,
     RELATED_TASK_META_KEY,
+    SUPPORTED_PROTOCOL_VERSIONS,
     BlobResourceContents,
     CallToolRequest,
     CallToolResult,
@@ -87,6 +89,8 @@ from arcade_mcp_server.types import (
     CompleteRequest,
     CreateMessageRequest,
     CreateTaskResult,
+    DiscoverRequest,
+    DiscoverResult,
     ElicitRequest,
     GetPromptRequest,
     GetPromptResult,
@@ -563,6 +567,7 @@ class MCPServer:
         return {
             "ping": self._handle_ping,
             "initialize": self._handle_initialize,
+            "server/discover": self._handle_discover,
             "tools/list": self._handle_list_tools,
             "tools/call": self._handle_call_tool,
             "resources/list": self._handle_list_resources,
@@ -755,7 +760,7 @@ class MCPServer:
         if (
             session
             and session.initialization_state != InitializationState.INITIALIZED
-            and method not in ["initialize", "ping"]
+            and method not in ["initialize", "ping", "server/discover"]
         ):
             return JSONRPCError(
                 id=msg_id,
@@ -900,6 +905,7 @@ class MCPServer:
         message_types = {
             "ping": PingRequest,
             "initialize": InitializeRequest,
+            "server/discover": DiscoverRequest,
             "tools/list": ListToolsRequest,
             "tools/call": CallToolRequest,
             "resources/list": ListResourcesRequest,
@@ -989,6 +995,22 @@ class MCPServer:
             instructions=self.instructions,
         )
 
+        return JSONRPCResponse(id=message.id, result=result)
+
+    async def _handle_discover(
+        self,
+        message: DiscoverRequest,
+        session: ServerSession | None = None,
+    ) -> JSONRPCResponse[DiscoverResult]:
+        """Advertise the server's stable, handshake-free protocol surface."""
+        result = DiscoverResult(
+            supportedVersions=SUPPORTED_PROTOCOL_VERSIONS,
+            capabilities=ServerCapabilities(
+                **self._build_capabilities(LATEST_PROTOCOL_VERSION, stateless=True)
+            ),
+            instructions=self.instructions,
+            serverInfo=Implementation(**self._build_server_info(LATEST_PROTOCOL_VERSION)),
+        )
         return JSONRPCResponse(id=message.id, result=result)
 
     def _build_capabilities(

--- a/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
@@ -139,6 +139,7 @@ def _validate_protocol_version_header(
     *,
     is_stateless: bool = False,
     is_initialize: bool = False,
+    is_discovery: bool = False,
 ) -> tuple[Response | None, str | None]:
     """Validate MCP-Protocol-Version header.
 
@@ -150,12 +151,22 @@ def _validate_protocol_version_header(
       in both stateful and stateless modes.
     - On non-initialize requests with no header, the server SHOULD
       assume protocol version ``2025-03-26`` for backwards compatibility.
+    - server/discover IS version discovery (it answers with
+      ``supportedVersions``), so it is likewise exempt: a client may
+      probe with any ``MCP-Protocol-Version``, including one the server
+      does not implement.
     """
     header_version = request.headers.get(MCP_PROTOCOL_VERSION_HEADER)
 
     # Initialize IS version negotiation: skip header validation in both modes.
     if is_initialize:
         return None, header_version
+
+    # Discovery IS version discovery: the response reports the implemented
+    # versions, so any header value must reach the handler. No version is
+    # returned -- a probe must not pin a negotiated version onto a session.
+    if is_discovery:
+        return None, None
 
     if is_stateless:
         if header_version is None:
@@ -334,12 +345,16 @@ class HTTPSessionManager:
 
         # --- Detect if this is an initialize request ---
         is_initialize = False
+        is_discovery_request = False
         body_bytes: bytes | None = None
         if request.method == "POST":
             try:
                 body_bytes = await request.body()
                 raw = json.loads(body_bytes) if body_bytes else {}
                 is_initialize = isinstance(raw, dict) and raw.get("method") == "initialize"
+                is_discovery_request = (
+                    isinstance(raw, dict) and raw.get("method") == "server/discover"
+                )
             except Exception:  # noqa: S110
                 pass
 
@@ -365,8 +380,13 @@ class HTTPSessionManager:
         # Initialize is exempt (it carries params.protocolVersion). For
         # other stateless requests without the header, the validator falls
         # back to 2025-03-26 per the spec's backwards-compatibility rule.
+        # Discovery is exempt as well: it answers with supportedVersions,
+        # so a probe may carry any protocol version.
         version_error, header_version = _validate_protocol_version_header(
-            request, is_stateless=True, is_initialize=is_initialize
+            request,
+            is_stateless=True,
+            is_initialize=is_initialize,
+            is_discovery=is_discovery_request,
         )
         if version_error is not None:
             await version_error(scope, receive, send)
@@ -494,7 +514,10 @@ class HTTPSessionManager:
             session = transport.session
 
         version_error, _ = _validate_protocol_version_header(
-            request, session=session, is_initialize=is_initialize
+            request,
+            session=session,
+            is_initialize=is_initialize,
+            is_discovery=is_discovery_request,
         )
         if version_error is not None:
             await version_error(scope, receive, send)

--- a/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
@@ -454,12 +454,16 @@ class HTTPSessionManager:
 
         # --- Detect if this is an initialize request ---
         is_initialize = False
+        is_discovery_request = False
         body_bytes: bytes | None = None
         if request.method == "POST" and request_mcp_session_id is None:
             try:
                 body_bytes = await request.body()
                 raw = json.loads(body_bytes) if body_bytes else {}
                 is_initialize = isinstance(raw, dict) and raw.get("method") == "initialize"
+                is_discovery_request = (
+                    isinstance(raw, dict) and raw.get("method") == "server/discover"
+                )
             except Exception:  # noqa: S110
                 pass
 
@@ -566,7 +570,17 @@ class HTTPSessionManager:
 
                 # Handle the HTTP request (replay body so inner Request() can
                 # read it on ASGI hosts that do not buffer receive()).
-                await http_transport.handle_request(scope, inner_receive, send)
+                if is_discovery_request and body_bytes is not None:
+                    # Discovery bootstraps the stateful transport, so let its
+                    # normal session validation see the ID just allocated.
+                    discovery_scope = dict(scope)
+                    discovery_scope["headers"] = [
+                        *scope.get("headers", []),
+                        (MCP_SESSION_ID_HEADER.lower().encode(), new_session_id.encode()),
+                    ]
+                    await http_transport.handle_request(discovery_scope, inner_receive, send)
+                else:
+                    await http_transport.handle_request(scope, inner_receive, send)
         else:
             # Invalid session ID
             response = Response(

--- a/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
@@ -473,10 +473,13 @@ class HTTPSessionManager:
         request_mcp_session_id = request.headers.get(MCP_SESSION_ID_HEADER)
 
         # --- Detect if this is an initialize request ---
+        # Method detection runs on every POST, including ones that carry a
+        # session ID: a discover retry reusing the session allocated by the
+        # first probe is still version discovery and must keep the exemption.
         is_initialize = False
         is_discovery_request = False
         body_bytes: bytes | None = None
-        if request.method == "POST" and request_mcp_session_id is None:
+        if request.method == "POST":
             try:
                 body_bytes = await request.body()
                 raw = json.loads(body_bytes) if body_bytes else {}

--- a/libs/arcade-mcp-server/arcade_mcp_server/types.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/types.py
@@ -222,6 +222,21 @@ class InitializeResult(Result):
     instructions: str | None = None
 
 
+class DiscoverRequest(JSONRPCRequest):
+    method: Literal["server/discover"] = Field(default="server/discover", frozen=True)
+    params: dict[str, Any] = Field(default_factory=dict)
+
+
+class DiscoverResult(Result):
+    supportedVersions: list[str]
+    capabilities: ServerCapabilities
+    resultType: Literal["complete"] = "complete"
+    ttlMs: int = 0
+    cacheScope: Literal["private", "public"] = "public"
+    instructions: str | None = None
+    serverInfo: Implementation | None = None
+
+
 class InitializedNotification(JSONRPCMessage, Notification):
     method: Literal["notifications/initialized"] = Field(
         default="notifications/initialized", frozen=True

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.26.0"
+version = "1.26.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/libs/tests/arcade_mcp_server/test_http_transport.py
+++ b/libs/tests/arcade_mcp_server/test_http_transport.py
@@ -47,9 +47,11 @@ def _make_request(headers: dict[str, str] | None = None, method: str = "POST") -
 
 
 @asynccontextmanager
-async def _http_client(mcp_server: MCPServer):
+async def _http_client(mcp_server: MCPServer, *, stateless: bool = False):
     mcp_server.allowed_origins = ["*"]
-    manager = HTTPSessionManager(server=mcp_server, json_response=True)
+    manager = HTTPSessionManager(
+        server=mcp_server, json_response=True, stateless=stateless
+    )
 
     async def mcp_endpoint(scope: Scope, receive: Receive, send: Send) -> None:
         await manager.handle_request(scope, receive, send)
@@ -99,6 +101,49 @@ class TestHandshakeFreeDiscovery:
         assert body["result"]["ttlMs"] == 0
         assert body["result"]["cacheScope"] == "public"
         assert resp.headers.get("Mcp-Session-Id")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("stateless", [False, True])
+    async def test_discover_with_unknown_protocol_version_returns_versions(
+        self, mcp_server: MCPServer, stateless: bool
+    ) -> None:
+        """A probe with an unimplemented MCP-Protocol-Version must still
+        receive supportedVersions -- rejecting it would defeat version
+        discovery for clients newer than the server."""
+        async with _http_client(mcp_server, stateless=stateless) as client:
+            resp = await client.post(
+                "/mcp/",
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                    "MCP-Protocol-Version": "2026-07-28",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "server/discover"},
+            )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["result"]["supportedVersions"] == [
+            "2025-06-18",
+            "2025-11-25",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_tools_list_with_unknown_protocol_version_still_rejected(
+        self, mcp_server: MCPServer
+    ) -> None:
+        """Ordinary methods keep the check: an unsupported version header
+        on tools/list still returns the transport 400."""
+        async with _http_client(mcp_server) as client:
+            resp = await client.post(
+                "/mcp/",
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                    "MCP-Protocol-Version": "2026-07-28",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            )
+        assert resp.status_code == 400, resp.text
+        assert "Unsupported protocol version" in resp.text
 
 
 class TestOriginValidation:

--- a/libs/tests/arcade_mcp_server/test_http_transport.py
+++ b/libs/tests/arcade_mcp_server/test_http_transport.py
@@ -7,11 +7,14 @@ level rather than via full ASGI integration.
 """
 
 import json
+from contextlib import asynccontextmanager
 from unittest.mock import Mock
 
+import httpx
 import pytest
-
+from arcade_mcp_server.server import MCPServer
 from arcade_mcp_server.transports.http_session_manager import (
+    HTTPSessionManager,
     _create_transport_error_response,
     _replay_receive,
     _validate_accept_header,
@@ -20,7 +23,10 @@ from arcade_mcp_server.transports.http_session_manager import (
 )
 from arcade_mcp_server.transports.http_streamable import HTTPStreamableTransport
 from arcade_mcp_server.types import JSONRPCError
+from starlette.applications import Starlette
 from starlette.requests import Request
+from starlette.routing import Mount
+from starlette.types import Receive, Scope, Send
 
 
 def _make_request(headers: dict[str, str] | None = None, method: str = "POST") -> Request:
@@ -39,6 +45,21 @@ def _make_request(headers: dict[str, str] | None = None, method: str = "POST") -
     return Request(scope)
 
 
+@asynccontextmanager
+async def _http_client(mcp_server: MCPServer):
+    mcp_server.allowed_origins = ["*"]
+    manager = HTTPSessionManager(server=mcp_server, json_response=True)
+
+    async def mcp_endpoint(scope: Scope, receive: Receive, send: Send) -> None:
+        await manager.handle_request(scope, receive, send)
+
+    app = Starlette(routes=[Mount("/mcp", app=mcp_endpoint)])
+    async with manager.run():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            yield client
+
+
 class TestTransportErrorHelper:
     """Transport-level JSON-RPC error response helper."""
 
@@ -54,6 +75,29 @@ class TestTransportErrorHelper:
         resp = _create_transport_error_response(403, "Forbidden", code=-32001)
         body = json.loads(resp.body)
         assert body["error"]["code"] == -32001
+
+
+class TestHandshakeFreeDiscovery:
+    @pytest.mark.asyncio
+    async def test_discover_without_session_id_returns_metadata(
+        self, mcp_server: MCPServer
+    ) -> None:
+        async with _http_client(mcp_server) as client:
+            resp = await client.post(
+                "/mcp/",
+                headers={
+                    "Accept": "application/json, text/event-stream",
+                    "Content-Type": "application/json",
+                },
+                json={"jsonrpc": "2.0", "id": 1, "method": "server/discover"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["result"]["supportedVersions"] == ["2025-06-18", "2025-11-25"]
+        assert body["result"]["resultType"] == "complete"
+        assert body["result"]["ttlMs"] == 0
+        assert body["result"]["cacheScope"] == "public"
+        assert resp.headers.get("Mcp-Session-Id")
 
 
 class TestOriginValidation:

--- a/libs/tests/arcade_mcp_server/test_http_transport.py
+++ b/libs/tests/arcade_mcp_server/test_http_transport.py
@@ -3,7 +3,8 @@
 Covers Origin validation, Accept header negotiation, the
 MCP-Protocol-Version header, CORS headers, the transport error helper,
 and session termination. These exercise the helpers at the function
-level rather than via full ASGI integration.
+level; the discovery regression also covers the stateful manager through a
+full ASGI request.
 """
 
 import json

--- a/libs/tests/arcade_mcp_server/test_http_transport.py
+++ b/libs/tests/arcade_mcp_server/test_http_transport.py
@@ -49,9 +49,7 @@ def _make_request(headers: dict[str, str] | None = None, method: str = "POST") -
 @asynccontextmanager
 async def _http_client(mcp_server: MCPServer, *, stateless: bool = False):
     mcp_server.allowed_origins = ["*"]
-    manager = HTTPSessionManager(
-        server=mcp_server, json_response=True, stateless=stateless
-    )
+    manager = HTTPSessionManager(server=mcp_server, json_response=True, stateless=stateless)
 
     async def mcp_endpoint(scope: Scope, receive: Receive, send: Send) -> None:
         await manager.handle_request(scope, receive, send)
@@ -125,6 +123,49 @@ class TestHandshakeFreeDiscovery:
             "2025-06-18",
             "2025-11-25",
         ]
+
+    @pytest.mark.asyncio
+    async def test_discover_reusing_session_id_with_unknown_protocol_version_returns_versions(
+        self, mcp_server: MCPServer
+    ) -> None:
+        """A discover retry that reuses the Mcp-Session-Id from the first
+        response is still version discovery: an unimplemented
+        MCP-Protocol-Version must reach the handler, not die at the
+        transport 400."""
+        async with _http_client(mcp_server) as client:
+            headers = {
+                "Accept": "application/json, text/event-stream",
+                "Content-Type": "application/json",
+                "MCP-Protocol-Version": "2026-07-28",
+            }
+            first = await client.post(
+                "/mcp/",
+                headers=headers,
+                json={"jsonrpc": "2.0", "id": 1, "method": "server/discover"},
+            )
+            assert first.status_code == 200, first.text
+            session_id = first.headers.get("Mcp-Session-Id")
+            assert session_id
+
+            retry = await client.post(
+                "/mcp/",
+                headers={**headers, "Mcp-Session-Id": session_id},
+                json={"jsonrpc": "2.0", "id": 2, "method": "server/discover"},
+            )
+            assert retry.status_code == 200, retry.text
+            assert retry.json()["result"]["supportedVersions"] == [
+                "2025-06-18",
+                "2025-11-25",
+            ]
+
+            # Ordinary methods on the same session keep the version check.
+            tools_list = await client.post(
+                "/mcp/",
+                headers={**headers, "Mcp-Session-Id": session_id},
+                json={"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+            )
+            assert tools_list.status_code == 400, tools_list.text
+            assert "Unsupported protocol version" in tools_list.text
 
     @pytest.mark.asyncio
     async def test_tools_list_with_unknown_protocol_version_still_rejected(
@@ -250,9 +291,7 @@ class TestMCPProtocolVersionHeader:
     def test_stateless_initialize_skips_header_requirement(self):
         """Stateless mode must also exempt initialize from the header check."""
         req = _make_request({})
-        error, _ = _validate_protocol_version_header(
-            req, is_stateless=True, is_initialize=True
-        )
+        error, _ = _validate_protocol_version_header(req, is_stateless=True, is_initialize=True)
         assert error is None
 
     def test_stateless_non_initialize_invalid_header_still_returns_400(self):

--- a/libs/tests/arcade_mcp_server/test_server.py
+++ b/libs/tests/arcade_mcp_server/test_server.py
@@ -428,6 +428,21 @@ class TestMCPServer:
         assert "cannot be processed before the session is initialized" in response.error["message"]
 
     @pytest.mark.asyncio
+    async def test_discover_is_available_before_initialization(self, mcp_server, server_session):
+        response = await mcp_server.handle_message(
+            {"jsonrpc": "2.0", "id": 1, "method": "server/discover"},
+            session=server_session,
+        )
+
+        assert isinstance(response, JSONRPCResponse)
+        assert response.result.supportedVersions == ["2025-06-18", "2025-11-25"]
+        assert response.result.resultType == "complete"
+        assert response.result.ttlMs == 0
+        assert response.result.cacheScope == "public"
+        assert response.result.serverInfo.name == "Test Server"
+        assert server_session.initialization_state == InitializationState.NOT_INITIALIZED
+
+    @pytest.mark.asyncio
     async def test_notification_handling(self, mcp_server):
         """Test handling of notification messages."""
         session = Mock()


### PR DESCRIPTION
## Summary

Adds a handshake-free `server/discover` response so clients can learn which MCP revisions Arcade currently serves before initialization. The response advertises only the implemented 2025-06-18 and 2025-11-25 revisions.

Resolves: #914

## Design decisions

- Discovery is public metadata with a zero TTL. It reports only capabilities that do not depend on a stateful session.
- The endpoint does not claim support for 2026-07-28's per-request version negotiation or result envelopes.

## Scope

In scope:

- pre-handshake protocol discovery
- the discovery result model and its focused regression test

Not in scope:

- 2026-07-28 request negotiation, result envelopes, or subscriptions

## Test plan

- [x] `uv run pytest libs/tests/arcade_mcp_server`
- [x] `make test` (3,734 passed, 1 skipped)
- [x] `uv run mypy libs/arcade-mcp-server/arcade_mcp_server`
- [x] `uv run ruff format --check` and `uv run ruff check` on the changed production modules
- [x] `npx @hasmcp/mcp-spec-test@latest --spec-version 2026-07-28` against a fresh scaffold: 13 passed, 0 failed; 23 current-revision checks are explicitly not verified because the server advertises only its two implemented 2025 revisions
- [ ] `make check` is blocked by NumPy typing syntax while it type-checks the untouched `arcade-cli` and `arcade-evals` packages; the changed MCP server package passes its mypy gate

## Risk note

This adds one read-only pre-handshake method. Other requests, including `tools/list`, still require initialization.

## Author checklist

Before moving this PR from Draft to Ready for Review:

- [x] Linked to a Linear ticket or GitHub issue (above)
- [x] I understand every change in the diff
- [x] Runs locally, exercised through the end-user path (not just unit tests)
- [ ] `make check` and `make test` are green locally; CI is expected to pass
- [x] I've pulled the branch fresh and reviewed my own diff top-to-bottom
- [x] I'd merge it myself if a teammate said LGTM right now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only pre-handshake metadata with narrow transport exemptions; existing init-gated behavior for operational methods is unchanged aside from the new discovery path.
> 
> **Overview**
> Adds **handshake-free MCP discovery** via a new `server/discover` JSON-RPC method so clients can read supported protocol revisions, capabilities, instructions, and server metadata **before** `initialize`.
> 
> The server handler registers `DiscoverRequest`/`DiscoverResult`, whitelists discovery alongside `ping`/`initialize` for pre-init calls, and returns `supportedVersions` (`2025-06-18`, `2025-11-25`) plus stateless-oriented capabilities built at the latest revision.
> 
> **HTTP transport** treats discovery like version negotiation: `MCP-Protocol-Version` checks are skipped (including retries with an unknown version and an existing `Mcp-Session-Id`), discovery probes do not pin a negotiated version on the session, and the stateful path injects the newly allocated session id on the first discover POST so the inner transport can validate the session.
> 
> Regression tests cover unit-level pre-init discovery and end-to-end ASGI flows for stateful/stateless modes, ensuring ordinary methods such as `tools/list` still reject unsupported protocol headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7770fb93062a398e17b88d4770d17a1ba475d2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

