### PR TITLE
feat(core): add a _meta field to ToolDefinition [TOO-1941]

### DIFF
--- a/libs/arcade-core/arcade_core/schema.py
+++ b/libs/arcade-core/arcade_core/schema.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal, Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from arcade_core.errors import ErrorKind
 from arcade_core.metadata import ToolMetadata
@@ -339,6 +339,13 @@ class ToolDefinition(BaseModel):
 
     metadata: ToolMetadata | None = None
     """Metadata about the tool"""
+
+    meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+    """Out-of-band data attached to the tool, carried through untouched."""
+
+    # Without this a ``meta=`` keyword is silently ignored, and a dump-then-validate
+    # round trip drops the field with no error.
+    model_config = ConfigDict(populate_by_name=True)
 
     def get_fully_qualified_name(self) -> FullyQualifiedName:
         return FullyQualifiedName(self.name, self.toolkit.name, self.toolkit.version)

--- a/libs/tests/core/test_tool_definition_meta.py
+++ b/libs/tests/core/test_tool_definition_meta.py
@@ -1,0 +1,64 @@
+"""A tool definition's ``_meta`` must serialize exactly as it goes on the wire.
+
+The alias is the wire contract: a caller decodes ``_meta``, so a value emitted
+under the Python name, or dropped between a dump and a validate, is a break.
+"""
+
+from arcade_core.schema import (
+    ToolDefinition,
+    ToolInput,
+    ToolkitDefinition,
+    ToolOutput,
+    ToolRequirements,
+)
+
+POINTER = {"ui": {"resourceUri": "ui://Math/0.1.0/sum-list.html"}}
+
+
+def _definition(**overrides) -> ToolDefinition:
+    fields = {
+        "name": "SumList",
+        "fully_qualified_name": "Math.SumList",
+        "description": "Sum a list of numbers",
+        "toolkit": ToolkitDefinition(name="Math", version="0.1.0"),
+        "input": ToolInput(parameters=[]),
+        "output": ToolOutput(),
+        "requirements": ToolRequirements(),
+    }
+    fields.update(overrides)
+    return ToolDefinition(**fields)
+
+
+def test_meta_serializes_under_the_underscore_key():
+    dumped = _definition(meta=POINTER).model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["_meta"] == POINTER
+    assert "meta" not in dumped
+
+
+def test_meta_is_read_from_the_underscore_key():
+    definition = ToolDefinition.model_validate({
+        **_definition().model_dump(exclude_none=True),
+        "_meta": POINTER,
+    })
+
+    assert definition.meta == POINTER
+
+
+def test_meta_survives_a_dump_and_validate_round_trip():
+    """``model_dump()`` emits the Python name, so validation has to accept it too."""
+    definition = _definition(meta=POINTER)
+
+    round_tripped = ToolDefinition.model_validate(definition.model_dump())
+
+    assert round_tripped.meta == POINTER
+
+
+def test_meta_is_absent_until_something_sets_it():
+    definition = _definition()
+
+    dumped = definition.model_dump(by_alias=True, exclude_none=True)
+
+    assert definition.meta is None
+    assert "_meta" not in dumped
+    assert "meta" not in dumped


### PR DESCRIPTION
## Summary

`ToolDefinition` gains a `_meta` field: out-of-band data attached to a tool, carried through untouched. On the wire it is spelled `_meta`; in Python it is `meta`. The catalog endpoint serializes by alias, so the key reaches the wire with no change to arcade-serve.

Part 1 of 2. TOO-1942 stacks on this and is what writes into the field.

Resolves: https://linear.app/arcadedev/issue/TOO-1941

## Design decisions

### `populate_by_name` is required, and omitting it fails silently

Without it a `meta=` keyword is silently ignored, and a `model_validate(model_dump())` round trip drops the field with no error, because `model_dump()` emits the Python name and validation accepts only the alias. The tests pin both directions and the round trip.

### The field is an untyped dict

A typed model here would pin arcade-core to one consumer's vocabulary and one version of it. What goes into the dict is decided by the code that writes it, one layer up.

### Every tool now serializes `"_meta": null`

The catalog endpoint does not exclude nulls, so a tool without out-of-band data emits the key as null, exactly as `deprecation_message` and `metadata` do today. A consumer decoding into an optional field reads null as absent.

~ 🐙 Eriq, Eric's Agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive schema field with tests; catalog responses may include `"_meta": null` for tools without data, matching existing optional fields like `metadata`.
> 
> **Overview**
> **`ToolDefinition`** now carries optional out-of-band data as **`meta`** in Python and **`_meta`** on the wire (`dict[str, Any] | None`), passed through without arcade-core interpreting it.
> 
> **`populate_by_name=True`** is set on the model so `meta=` is not ignored and **`model_dump()` → `model_validate()`** round trips keep the field (alias-only validation would drop it silently).
> 
> New tests lock the contract: alias serialization, reading from **`_meta`**, round trip, and omission when unset (with **`exclude_none=True`**, the key is absent until populated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 066b250d5f8e03e30646a633ecb8377257f55cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->