### PR TITLE
feat(core): let a tool name its user interface [TOO-1941, TOO-1942]

### DIFF
--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -39,8 +39,6 @@ from arcade_core.resources import (
     InvalidResourcePathError,
     ResourceDeclaration,
     ResourceRegistry,
-    as_interface,
-    declared_contents,
     qualify,
     ui_pointer,
 )
@@ -172,10 +170,6 @@ class ToolCatalog(BaseModel):
     # worker surface. They are a separate collection with separate types; the
     # catalog is the carrier, not the owner.
     _resources: ResourceRegistry = PrivateAttr(default_factory=ResourceRegistry)
-    # URI to the declaration registered there and what registered it, so a second
-    # declaration of one path is refused and the same declaration reached twice,
-    # from two tools or from the module scan after a tool, is not.
-    _declared: dict[str, tuple[ResourceDeclaration, str]] = PrivateAttr(default_factory=dict)
 
     def __init__(self, **data) -> None:  # type: ignore[no-untyped-def]
         super().__init__(**data)
@@ -281,22 +275,19 @@ class ToolCatalog(BaseModel):
             logger.info(f"Server '{toolkit_name!s}' is disabled and will not be cataloged.")
             return
 
-        interface = getattr(tool_func, "__tool_ui__", None)
-        if interface is not None:
+        ui = getattr(tool_func, "__tool_ui__", None)
+        if ui is not None:
             try:
-                self._register_resource(
-                    interface,
-                    str(fully_qualified_name),
+                self._resources.declare(
+                    ui,
                     toolkit_name=definition.toolkit.name,
                     toolkit_version=definition.toolkit.version,
-                    as_tool_interface=True,
+                    as_interface=True,
                 )
-            except ToolkitLoadError:
-                raise
             except Exception as e:
                 raise ToolDefinitionError(
-                    f"Tool '{definition.name}' names {interface.name!r} as its user interface, "
-                    f"which could not be registered. Reason: {e}"
+                    f"Tool '{definition.name}' names {ui.name!r} as its user interface, which "
+                    f"could not be registered. Reason: {e}"
                 ) from e
 
         self._tools[fully_qualified_name] = MaterializedTool(
@@ -430,66 +421,15 @@ class ToolCatalog(BaseModel):
                         f"declaration. A decorator above @resource is replacing it."
                     ).with_context(toolkit.name)
 
-                owner = f"{module_name}.{resource_name}"
                 try:
-                    self._register_resource(
-                        declaration,
-                        owner,
-                        toolkit_name=toolkit_name,
-                        toolkit_version=toolkit_version,
+                    self._resources.declare(
+                        declaration, toolkit_name=toolkit_name, toolkit_version=toolkit_version
                     )
-                except ToolkitLoadError as e:
-                    raise e.with_context(toolkit.name) from e
                 except Exception as e:
                     raise ToolkitLoadError(
                         f"Could not register resource {resource_name} from {module_name}. "
                         f"Reason: {e}"
                     ).with_context(toolkit.name) from e
-
-    def _register_resource(
-        self,
-        declaration: ResourceDeclaration,
-        owner: str,
-        *,
-        toolkit_name: str,
-        toolkit_version: str | None,
-        as_tool_interface: bool = False,
-    ) -> None:
-        """Register one declaration under the toolkit's URI, once.
-
-        The URI is derived before anything is declared, because declare replaces
-        whatever is already at a URI and a check run afterwards would raise over
-        a resource it had just destroyed.
-        """
-        if toolkit_version is None:
-            raise ToolkitLoadError(
-                f"{owner} declares resource {declaration.name!r}, but the toolkit has no "
-                f"version, so no URI can be derived for it."
-            )
-
-        registered = as_interface(declaration) if as_tool_interface else declaration
-        uri = self._resources.uri_for(
-            registered, toolkit_name=toolkit_name, toolkit_version=toolkit_version
-        )
-
-        already = self._declared.get(uri)
-        if already is not None:
-            if already[0] == declaration:
-                return
-            # Two resources sharing a path is an authoring mistake, and this is
-            # the only point where both are in scope.
-            raise ToolkitLoadError(
-                f"{owner} and {already[1]} both declare {uri}. Two resources in one toolkit "
-                f"cannot share a path."
-            )
-
-        self._resources.declare(
-            registered,
-            declared_contents(registered),
-            toolkit_name=toolkit_name,
-            toolkit_version=toolkit_version,
-        )
-        self._declared[uri] = (declaration, owner)
 
     def __getitem__(self, name: FullyQualifiedName) -> MaterializedTool:
         return self.get_tool(name)
@@ -630,14 +570,14 @@ class ToolCatalog(BaseModel):
             tool_metadata.validate_for_tool()
 
         meta = None
-        interface = getattr(tool, "__tool_ui__", None)
-        if interface is not None:
-            if not isinstance(interface, ResourceDeclaration):
+        ui = getattr(tool, "__tool_ui__", None)
+        if ui is not None:
+            if not isinstance(ui, ResourceDeclaration):
                 raise ToolDefinitionError(
-                    f"Tool '{raw_tool_name}' passes a {type(interface).__name__} as its ui. Pass "
-                    f"the declaration @resource returns."
+                    f"Tool '{raw_tool_name}' passes a {type(ui).__name__} as its ui. Pass the "
+                    f"declaration @resource returns."
                 )
-            meta = ui_pointer(_interface_uri(raw_tool_name, interface, toolkit_definition))
+            meta = ui_pointer(_interface_uri(raw_tool_name, ui, toolkit_definition))
 
         return ToolDefinition(
             name=tool_name,

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -40,6 +40,7 @@ from arcade_core.resources import (
     InvalidResourcePathError,
     ResourceRegistry,
     qualify,
+    read_declared_file,
     ui_pointer,
     ui_resource_uri,
 )
@@ -437,7 +438,7 @@ class ToolCatalog(BaseModel):
                 try:
                     self._resources.declare(
                         declaration,
-                        func(),
+                        read_declared_file(declaration) if declaration.file else func(),
                         toolkit_name=normalize_toolkit_name(toolkit.name),
                         toolkit_version=toolkit_version,
                     )

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -605,12 +605,10 @@ class ToolCatalog(BaseModel):
                 )
             tool_metadata.validate_for_tool()
 
+        meta = None
         ui_path = getattr(tool, "__tool_ui__", None)
-        meta = (
-            ui_pointer(_ui_uri(raw_tool_name, ui_path, toolkit_definition))
-            if ui_path is not None
-            else None
-        )
+        if ui_path is not None:
+            meta = ui_pointer(_ui_uri(raw_tool_name, ui_path, toolkit_definition))
 
         return ToolDefinition(
             name=tool_name,

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -35,7 +35,14 @@ from arcade_core.errors import (
     ToolOutputSchemaError,
 )
 from arcade_core.metadata import ToolMetadata
-from arcade_core.resources import RESOURCE_ATTRIBUTE, ResourceRegistry
+from arcade_core.resources import (
+    RESOURCE_ATTRIBUTE,
+    InvalidResourcePathError,
+    ResourceRegistry,
+    qualify,
+    ui_pointer,
+    ui_resource_uri,
+)
 from arcade_core.schema import (
     TOOL_NAME_SEPARATOR,
     FullyQualifiedName,
@@ -442,6 +449,24 @@ class ToolCatalog(BaseModel):
 
                 claimed[uri] = owner
 
+        # A tool may name only an interface this toolkit serves. Both sides are
+        # registered by this point, so this is the first place the check can run.
+        normalized_name = normalize_toolkit_name(toolkit.name)
+        for materialized in self._tools.values():
+            definition = materialized.definition
+            if (definition.toolkit.name, definition.toolkit.version) != (
+                normalized_name,
+                toolkit_version,
+            ):
+                continue
+            pointed = ui_resource_uri(definition.meta)
+            if pointed is not None and pointed not in self._resources:
+                raise ToolkitLoadError(
+                    f"{definition.fully_qualified_name} names its interface at {pointed}, but "
+                    f"no resource in this toolkit is registered there. Declare it with "
+                    f"@resource using the same path."
+                ).with_context(toolkit.name)
+
     def __getitem__(self, name: FullyQualifiedName) -> MaterializedTool:
         return self.get_tool(name)
 
@@ -580,6 +605,13 @@ class ToolCatalog(BaseModel):
                 )
             tool_metadata.validate_for_tool()
 
+        ui_path = getattr(tool, "__tool_ui__", None)
+        meta = (
+            ui_pointer(_ui_uri(raw_tool_name, ui_path, toolkit_definition))
+            if ui_path is not None
+            else None
+        )
+
         return ToolDefinition(
             name=tool_name,
             fully_qualified_name=str(fully_qualified_name),
@@ -594,7 +626,24 @@ class ToolCatalog(BaseModel):
             ),
             deprecation_message=deprecation_message,
             metadata=tool_metadata,
+            _meta=meta,
         )
+
+
+def _ui_uri(tool_name: str, path: str, toolkit: ToolkitDefinition) -> str:
+    """Qualify the path a tool names, exactly as the resource at that path is."""
+    if toolkit.version is None:
+        raise ToolDefinitionError(
+            f"Tool '{tool_name}' names its interface at {path!r}, but the toolkit has no "
+            f"version, so no URI can be derived for it."
+        )
+    try:
+        return qualify(toolkit.name, toolkit.version, path)
+    except InvalidResourcePathError as e:
+        raise ToolDefinitionError(
+            f"Tool '{tool_name}' names its interface at {path!r}, which is not a usable "
+            f"resource path. Reason: {e}"
+        ) from e
 
 
 def create_input_definition(func: Callable) -> ToolInput:

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -36,13 +36,13 @@ from arcade_core.errors import (
 )
 from arcade_core.metadata import ToolMetadata
 from arcade_core.resources import (
-    RESOURCE_ATTRIBUTE,
     InvalidResourcePathError,
+    ResourceDeclaration,
     ResourceRegistry,
+    as_interface,
+    declared_contents,
     qualify,
-    read_declared_file,
     ui_pointer,
-    ui_resource_uri,
 )
 from arcade_core.schema import (
     TOOL_NAME_SEPARATOR,
@@ -172,6 +172,10 @@ class ToolCatalog(BaseModel):
     # worker surface. They are a separate collection with separate types; the
     # catalog is the carrier, not the owner.
     _resources: ResourceRegistry = PrivateAttr(default_factory=ResourceRegistry)
+    # URI to the declaration registered there and what registered it, so a second
+    # declaration of one path is refused and the same declaration reached twice,
+    # from two tools or from the module scan after a tool, is not.
+    _declared: dict[str, tuple[ResourceDeclaration, str]] = PrivateAttr(default_factory=dict)
 
     def __init__(self, **data) -> None:  # type: ignore[no-untyped-def]
         super().__init__(**data)
@@ -277,6 +281,24 @@ class ToolCatalog(BaseModel):
             logger.info(f"Server '{toolkit_name!s}' is disabled and will not be cataloged.")
             return
 
+        interface = getattr(tool_func, "__tool_ui__", None)
+        if interface is not None:
+            try:
+                self._register_resource(
+                    interface,
+                    str(fully_qualified_name),
+                    toolkit_name=definition.toolkit.name,
+                    toolkit_version=definition.toolkit.version,
+                    as_tool_interface=True,
+                )
+            except ToolkitLoadError:
+                raise
+            except Exception as e:
+                raise ToolDefinitionError(
+                    f"Tool '{definition.name}' names {interface.name!r} as its user interface, "
+                    f"which could not be registered. Reason: {e}"
+                ) from e
+
         self._tools[fully_qualified_name] = MaterializedTool(
             definition=definition,
             tool=tool_func,
@@ -375,8 +397,8 @@ class ToolCatalog(BaseModel):
             # published for a toolkit whose tools are hidden.
             return
 
+        toolkit_name = normalize_toolkit_name(toolkit.name)
         toolkit_version = version or toolkit.version
-        claimed: dict[str, str] = {}
 
         for module_name, resource_names in (toolkit.resources or {}).items():
             try:
@@ -387,8 +409,8 @@ class ToolCatalog(BaseModel):
                 ).with_context(toolkit.name) from e
 
             for resource_name in resource_names:
-                func = getattr(module, resource_name, None)
-                if func is None:
+                declaration = getattr(module, resource_name, None)
+                if declaration is None:
                     # Discovery reads the source, so a declaration the module
                     # guards behind something false at import time is found there
                     # and absent here. Skipping is what stops one unreachable
@@ -399,74 +421,75 @@ class ToolCatalog(BaseModel):
                     )
                     continue
 
-                declaration = getattr(func, RESOURCE_ATTRIBUTE, None)
-                if declaration is None:
-                    # The attribute is here and the marker is not, so something
-                    # replaced the function after @resource ran.
+                if not isinstance(declaration, ResourceDeclaration):
+                    # Discovery saw the decorator in the source, so something above
+                    # @resource replaced what it returned.
                     raise ToolkitLoadError(
                         f"{module_name}.{resource_name} is declared with @resource but the "
-                        f"module attribute carries no declaration. A decorator above @resource is "
-                        f"replacing the function without copying its attributes; wrap it "
-                        f"with functools.wraps."
+                        f"module attribute is a {type(declaration).__name__}, not the "
+                        f"declaration. A decorator above @resource is replacing it."
                     ).with_context(toolkit.name)
 
                 owner = f"{module_name}.{resource_name}"
-
-                # Derived before declaring, because declare replaces whatever is
-                # already at a URI. Checked afterwards, the guard would raise
-                # over a resource it had just destroyed.
                 try:
-                    uri = self._resources.uri_for(
+                    self._register_resource(
                         declaration,
-                        toolkit_name=normalize_toolkit_name(toolkit.name),
+                        owner,
+                        toolkit_name=toolkit_name,
                         toolkit_version=toolkit_version,
                     )
-                except Exception as e:
-                    raise ToolkitLoadError(
-                        f"Could not build a URI for resource {resource_name} from "
-                        f"{module_name}. Reason: {e}"
-                    ).with_context(toolkit.name) from e
-
-                if uri in claimed:
-                    # Two resources sharing a path is an authoring mistake, and
-                    # this is the only point where both are in scope.
-                    raise ToolkitLoadError(
-                        f"{owner} and {claimed[uri]} both declare {uri}. Two resources "
-                        f"in one toolkit cannot share a path."
-                    ).with_context(toolkit.name)
-
-                try:
-                    self._resources.declare(
-                        declaration,
-                        read_declared_file(declaration) if declaration.file else func(),
-                        toolkit_name=normalize_toolkit_name(toolkit.name),
-                        toolkit_version=toolkit_version,
-                    )
+                except ToolkitLoadError as e:
+                    raise e.with_context(toolkit.name) from e
                 except Exception as e:
                     raise ToolkitLoadError(
                         f"Could not register resource {resource_name} from {module_name}. "
                         f"Reason: {e}"
                     ).with_context(toolkit.name) from e
 
-                claimed[uri] = owner
+    def _register_resource(
+        self,
+        declaration: ResourceDeclaration,
+        owner: str,
+        *,
+        toolkit_name: str,
+        toolkit_version: str | None,
+        as_tool_interface: bool = False,
+    ) -> None:
+        """Register one declaration under the toolkit's URI, once.
 
-        # A tool may name only an interface this toolkit serves. Both sides are
-        # registered by this point, so this is the first place the check can run.
-        normalized_name = normalize_toolkit_name(toolkit.name)
-        for materialized in self._tools.values():
-            definition = materialized.definition
-            if (definition.toolkit.name, definition.toolkit.version) != (
-                normalized_name,
-                toolkit_version,
-            ):
-                continue
-            pointed = ui_resource_uri(definition.meta)
-            if pointed is not None and pointed not in self._resources:
-                raise ToolkitLoadError(
-                    f"{definition.fully_qualified_name} names its interface at {pointed}, but "
-                    f"no resource in this toolkit is registered there. Declare it with "
-                    f"@resource using the same path."
-                ).with_context(toolkit.name)
+        The URI is derived before anything is declared, because declare replaces
+        whatever is already at a URI and a check run afterwards would raise over
+        a resource it had just destroyed.
+        """
+        if toolkit_version is None:
+            raise ToolkitLoadError(
+                f"{owner} declares resource {declaration.name!r}, but the toolkit has no "
+                f"version, so no URI can be derived for it."
+            )
+
+        registered = as_interface(declaration) if as_tool_interface else declaration
+        uri = self._resources.uri_for(
+            registered, toolkit_name=toolkit_name, toolkit_version=toolkit_version
+        )
+
+        already = self._declared.get(uri)
+        if already is not None:
+            if already[0] == declaration:
+                return
+            # Two resources sharing a path is an authoring mistake, and this is
+            # the only point where both are in scope.
+            raise ToolkitLoadError(
+                f"{owner} and {already[1]} both declare {uri}. Two resources in one toolkit "
+                f"cannot share a path."
+            )
+
+        self._resources.declare(
+            registered,
+            declared_contents(registered),
+            toolkit_name=toolkit_name,
+            toolkit_version=toolkit_version,
+        )
+        self._declared[uri] = (declaration, owner)
 
     def __getitem__(self, name: FullyQualifiedName) -> MaterializedTool:
         return self.get_tool(name)
@@ -607,9 +630,14 @@ class ToolCatalog(BaseModel):
             tool_metadata.validate_for_tool()
 
         meta = None
-        ui_path = getattr(tool, "__tool_ui__", None)
-        if ui_path is not None:
-            meta = ui_pointer(_ui_uri(raw_tool_name, ui_path, toolkit_definition))
+        interface = getattr(tool, "__tool_ui__", None)
+        if interface is not None:
+            if not isinstance(interface, ResourceDeclaration):
+                raise ToolDefinitionError(
+                    f"Tool '{raw_tool_name}' passes a {type(interface).__name__} as its ui. Pass "
+                    f"the declaration @resource returns."
+                )
+            meta = ui_pointer(_interface_uri(raw_tool_name, interface, toolkit_definition))
 
         return ToolDefinition(
             name=tool_name,
@@ -629,19 +657,21 @@ class ToolCatalog(BaseModel):
         )
 
 
-def _ui_uri(tool_name: str, path: str, toolkit: ToolkitDefinition) -> str:
-    """Qualify the path a tool names, exactly as the resource at that path is."""
+def _interface_uri(
+    tool_name: str, declaration: ResourceDeclaration, toolkit: ToolkitDefinition
+) -> str:
+    """Qualify the declaration a tool names, exactly as its registration does."""
     if toolkit.version is None:
         raise ToolDefinitionError(
-            f"Tool '{tool_name}' names its interface at {path!r}, but the toolkit has no "
-            f"version, so no URI can be derived for it."
+            f"Tool '{tool_name}' names {declaration.name!r} as its user interface, but the "
+            f"toolkit has no version, so no URI can be derived for it."
         )
     try:
-        return qualify(toolkit.name, toolkit.version, path)
+        return qualify(toolkit.name, toolkit.version, declaration.path, declaration.scheme)
     except InvalidResourcePathError as e:
         raise ToolDefinitionError(
-            f"Tool '{tool_name}' names its interface at {path!r}, which is not a usable "
-            f"resource path. Reason: {e}"
+            f"Tool '{tool_name}' names {declaration.name!r} as its user interface, but its "
+            f"path {declaration.path!r} is not usable. Reason: {e}"
         ) from e
 
 

--- a/libs/arcade-core/arcade_core/catalog.py
+++ b/libs/arcade-core/arcade_core/catalog.py
@@ -39,7 +39,7 @@ from arcade_core.resources import (
     InvalidResourcePathError,
     ResourceDeclaration,
     ResourceRegistry,
-    qualify,
+    interface_uri,
     ui_pointer,
 )
 from arcade_core.schema import (
@@ -600,14 +600,16 @@ class ToolCatalog(BaseModel):
 def _interface_uri(
     tool_name: str, declaration: ResourceDeclaration, toolkit: ToolkitDefinition
 ) -> str:
-    """Qualify the declaration a tool names, exactly as its registration does."""
+    """Qualify the declaration a tool names, through the derivation registration uses."""
     if toolkit.version is None:
         raise ToolDefinitionError(
             f"Tool '{tool_name}' names {declaration.name!r} as its user interface, but the "
             f"toolkit has no version, so no URI can be derived for it."
         )
     try:
-        return qualify(toolkit.name, toolkit.version, declaration.path, declaration.scheme)
+        return interface_uri(
+            declaration, toolkit_name=toolkit.name, toolkit_version=toolkit.version
+        )
     except InvalidResourcePathError as e:
         raise ToolDefinitionError(
             f"Tool '{tool_name}' names {declaration.name!r} as its user interface, but its "

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -32,6 +32,18 @@ _CURSOR_PREFIX = "after:"
 UI_SCHEME = "ui"
 
 
+def ui_pointer(uri: str) -> dict[str, Any]:
+    """The out-of-band entry on a tool that names its user interface."""
+    return {"ui": {"resourceUri": uri}}
+
+
+def ui_resource_uri(meta: dict[str, Any] | None) -> str | None:
+    """The interface a tool's out-of-band data names, or None when it names none."""
+    ui = (meta or {}).get("ui")
+    uri = ui.get("resourceUri") if isinstance(ui, dict) else None
+    return uri if isinstance(uri, str) else None
+
+
 class InvalidCursorError(ValueError):
     """Raised when a caller sends a cursor this registry did not issue."""
 
@@ -171,6 +183,12 @@ def resource(
         @resource(path="draft-review.html", mime_type="text/html")
         def draft_review() -> str:
             return (Path(__file__).parent / "draft-review.html").read_text()
+
+    A tool names its interface by the same path, and the same derivation
+    gives both the same URI::
+
+        @tool(ui="draft-review.html")
+        def draft_email(...) -> ...: ...
 
     The declaration is read when the toolkit is added to a catalog. Discovery
     scans for the decorator at module scope, so a declaration inside a class

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -11,9 +11,11 @@ import base64
 import binascii
 import inspect
 import re
+import sys
 from bisect import bisect_right, insort
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, TypeVar
 from urllib.parse import quote
 
@@ -30,6 +32,10 @@ _CURSOR_PREFIX = "after:"
 #: The scheme a tool's user interface is addressed under. Hosts that render an
 #: interface require it and refuse anything else.
 UI_SCHEME = "ui"
+
+#: The media type a host requires of a document it renders as a tool's user
+#: interface. Compared byte for byte, so the spacing and casing are part of it.
+UI_DOCUMENT_MIME_TYPE = "text/html;profile=mcp-app"
 
 
 def ui_pointer(uri: str) -> dict[str, Any]:
@@ -154,6 +160,26 @@ class ResourceDeclaration:
     title: str | None = None
     description: str | None = None
     mime_type: str | None = None
+    #: A file beside the declaring module whose contents the resource serves.
+    file: Path | None = None
+
+
+def read_declared_file(declaration: ResourceDeclaration) -> str | bytes:
+    """The contents of a declaration's file, as text when its media type is text."""
+    if declaration.file is None:
+        raise ValueError(f"resource {declaration.name!r} declares no file")
+    if (declaration.mime_type or "").startswith("text/"):
+        return declaration.file.read_text(encoding="utf-8")
+    return declaration.file.read_bytes()
+
+
+def _beside(func: Callable[..., Any], file: str) -> Path:
+    """The file's location, resolved against the module that declares the resource."""
+    module = sys.modules.get(func.__module__)
+    module_file = getattr(module, "__file__", None) or inspect.getsourcefile(func)
+    if module_file is None:
+        raise TypeError(f"@resource(file={file!r}) needs a module with a file to resolve against")
+    return Path(module_file).parent / file
 
 
 #: Attribute the decorator leaves on a function so registration can find the
@@ -164,8 +190,9 @@ F = TypeVar("F", bound=Callable[..., Any])
 
 
 def resource(
-    path: str,
+    path: str | None = None,
     *,
+    file: str | None = None,
     name: str | None = None,
     title: str | None = None,
     description: str | None = None,
@@ -174,18 +201,24 @@ def resource(
 ) -> Callable[[F], F]:
     """Declare a static resource a toolkit ships.
 
-    The decorated function returns the bytes. It is called once, when the
-    toolkit is registered, and never on a request.
+    The simplest declaration names a file beside the declaring module. It is
+    read once, when the toolkit is registered, and the resource takes the
+    file's name as its path::
 
-    The author gives a path relative to the toolkit. The full URI is derived at
-    registration, where the toolkit's name and version are known::
+        @resource(file="draft-review.html", mime_type=UI_DOCUMENT_MIME_TYPE)
+        def draft_review() -> None: ...
+
+    A function body can produce the contents instead, as text or bytes. It is
+    called once at registration and never on a request::
 
         @resource(path="draft-review.html", mime_type="text/html")
         def draft_review() -> str:
-            return (Path(__file__).parent / "draft-review.html").read_text()
+            return render("draft-review.html")
 
-    A tool names its interface by the same path, and the same derivation
-    gives both the same URI::
+    The path is relative to the toolkit. The full URI is derived at
+    registration, where the toolkit's name and version are known. A tool names
+    its interface by the same path, and the same derivation gives both the
+    same URI::
 
         @tool(ui="draft-review.html")
         def draft_email(...) -> ...: ...
@@ -194,6 +227,12 @@ def resource(
     scans for the decorator at module scope, so a declaration inside a class
     body or nested in another function is not found.
     """
+
+    if path is None:
+        if file is None:
+            raise TypeError("@resource needs a path or a file")
+        path = Path(file).name
+    resource_path = path
 
     def decorator(func: F) -> F:
         if inspect.iscoroutinefunction(func):
@@ -209,12 +248,13 @@ def resource(
             func,
             RESOURCE_ATTRIBUTE,
             ResourceDeclaration(
-                path=path,
+                path=resource_path,
                 name=name or func.__name__,
                 scheme=scheme,
                 title=title,
                 description=description,
                 mime_type=mime_type,
+                file=_beside(func, file) if file is not None else None,
             ),
         )
         return func

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -12,7 +12,7 @@ import binascii
 import inspect
 import re
 from bisect import bisect_right, insort
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any, TypeVar
 from urllib.parse import quote
@@ -258,6 +258,10 @@ class ResourceRegistry:
 
     def __contains__(self, uri: object) -> bool:
         return uri in self._resources
+
+    def __iter__(self) -> Iterator[RegisteredResource]:
+        """Every registered resource, in URI order."""
+        return (self._resources[uri] for uri in self._uris)
 
     def add(self, resource: Resource, contents: str | bytes) -> RegisteredResource:
         """Register a resource at its own URI, replacing any resource already there.

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -14,9 +14,9 @@ import re
 import sys
 from bisect import bisect_right, insort
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any
 from urllib.parse import quote
 
 from arcade_core.resource_schema import (
@@ -41,13 +41,6 @@ UI_DOCUMENT_MIME_TYPE = "text/html;profile=mcp-app"
 def ui_pointer(uri: str) -> dict[str, Any]:
     """The out-of-band entry on a tool that names its user interface."""
     return {"ui": {"resourceUri": uri}}
-
-
-def ui_resource_uri(meta: dict[str, Any] | None) -> str | None:
-    """The interface a tool's out-of-band data names, or None when it names none."""
-    ui = (meta or {}).get("ui")
-    uri = ui.get("resourceUri") if isinstance(ui, dict) else None
-    return uri if isinstance(uri, str) else None
 
 
 class InvalidCursorError(ValueError):
@@ -152,7 +145,12 @@ def qualify(toolkit_name: str, toolkit_version: str, path: str, scheme: str = UI
 
 @dataclass(frozen=True)
 class ResourceDeclaration:
-    """What a toolkit author writes. The URI is derived, never typed."""
+    """What a toolkit author writes. The URI is derived, never typed.
+
+    ``@resource`` returns one of these in place of the function it decorates, so
+    the name a module binds is the declaration itself, ready to be imported and
+    passed to a tool as its ``ui``.
+    """
 
     path: str
     name: str
@@ -162,15 +160,45 @@ class ResourceDeclaration:
     mime_type: str | None = None
     #: A file beside the declaring module whose contents the resource serves.
     file: Path | None = None
+    #: Produces the contents when no file is declared. Called once, at registration.
+    func: Callable[[], Any] | None = field(default=None, compare=False, repr=False)
+
+    def __call__(self) -> Any:
+        """Run the declaring function, so a toolkit's own tests can call it directly."""
+        if self.func is None:
+            raise TypeError(f"resource {self.name!r} has no function to call")
+        return self.func()
 
 
-def read_declared_file(declaration: ResourceDeclaration) -> str | bytes:
-    """The contents of a declaration's file, as text when its media type is text."""
-    if declaration.file is None:
-        raise ValueError(f"resource {declaration.name!r} declares no file")
-    if (declaration.mime_type or "").startswith("text/"):
-        return declaration.file.read_text(encoding="utf-8")
-    return declaration.file.read_bytes()
+def declared_contents(declaration: ResourceDeclaration) -> Any:
+    """Resolve a declaration's contents once: its file's, or what its function returns."""
+    if declaration.file is not None:
+        if (declaration.mime_type or "").startswith("text/"):
+            return declaration.file.read_text(encoding="utf-8")
+        return declaration.file.read_bytes()
+    return declaration()
+
+
+def as_interface(declaration: ResourceDeclaration) -> ResourceDeclaration:
+    """The declaration as a host needs it to render a tool's user interface.
+
+    A host renders only ``ui://`` documents of exactly one media type. A
+    declaration that leaves the media type unset gets it here. One that names
+    another cannot be rendered, and saying so at load beats a blank panel.
+    """
+    if declaration.scheme != UI_SCHEME:
+        raise ValueError(
+            f"resource {declaration.name!r} is declared under the {declaration.scheme!r} scheme, "
+            f"and a user interface must be declared under {UI_SCHEME!r}"
+        )
+    if declaration.mime_type is None:
+        return replace(declaration, mime_type=UI_DOCUMENT_MIME_TYPE)
+    if declaration.mime_type != UI_DOCUMENT_MIME_TYPE:
+        raise ValueError(
+            f"resource {declaration.name!r} is declared as {declaration.mime_type!r}, and a host "
+            f"renders a user interface only as {UI_DOCUMENT_MIME_TYPE!r}. Leave mime_type unset."
+        )
+    return declaration
 
 
 def _beside(func: Callable[..., Any], file: str) -> Path:
@@ -182,13 +210,6 @@ def _beside(func: Callable[..., Any], file: str) -> Path:
     return Path(module_file).parent / file
 
 
-#: Attribute the decorator leaves on a function so registration can find the
-#: declaration after discovery imports the module.
-RESOURCE_ATTRIBUTE = "__arcade_resource__"
-
-F = TypeVar("F", bound=Callable[..., Any])
-
-
 def resource(
     path: str | None = None,
     *,
@@ -198,34 +219,34 @@ def resource(
     description: str | None = None,
     mime_type: str | None = None,
     scheme: str = UI_SCHEME,
-) -> Callable[[F], F]:
+) -> Callable[[Callable[..., Any]], ResourceDeclaration]:
     """Declare a static resource a toolkit ships.
 
-    The simplest declaration names a file beside the declaring module. It is
-    read once, when the toolkit is registered, and the resource takes the
-    file's name as its path::
+    The decorated name becomes the declaration. The simplest one names a file
+    beside the declaring module; it is read once, when the toolkit is
+    registered, and the resource takes the file's name as its path. A tool
+    imports the declaration and passes it as its ``ui``, and the two are
+    qualified into one URI at registration::
 
-        @resource(file="draft-review.html", mime_type=UI_DOCUMENT_MIME_TYPE)
+        @resource(file="draft-review.html")
         def draft_review() -> None: ...
 
+        @tool(ui=draft_review)
+        def draft_email(...) -> ...: ...
+
     A function body can produce the contents instead, as text or bytes. It is
-    called once at registration and never on a request::
+    called once at registration and never on a request, and the declaration
+    stays callable so the toolkit's own tests can run it::
 
         @resource(path="draft-review.html", mime_type="text/html")
         def draft_review() -> str:
             return render("draft-review.html")
 
-    The path is relative to the toolkit. The full URI is derived at
-    registration, where the toolkit's name and version are known. A tool names
-    its interface by the same path, and the same derivation gives both the
-    same URI::
-
-        @tool(ui="draft-review.html")
-        def draft_email(...) -> ...: ...
-
-    The declaration is read when the toolkit is added to a catalog. Discovery
-    scans for the decorator at module scope, so a declaration inside a class
-    body or nested in another function is not found.
+    The docstring is the description unless one is given. A declaration a
+    tool passes as its ``ui`` is registered with that tool and needs no media
+    type. Any other declaration is found by scanning for the decorator at
+    module scope, so one inside a class body or nested in another function is
+    not found.
     """
 
     if path is None:
@@ -234,7 +255,7 @@ def resource(
         path = Path(file).name
     resource_path = path
 
-    def decorator(func: F) -> F:
+    def decorator(func: Callable[..., Any]) -> ResourceDeclaration:
         if inspect.iscoroutinefunction(func):
             # Registration calls this once, synchronously, inside add_toolkit.
             # Without this the coroutine reaches the contents model and surfaces
@@ -244,20 +265,16 @@ def resource(
                 "A resource is resolved once at registration on a synchronous "
                 "path, so its function must be synchronous."
             )
-        setattr(
-            func,
-            RESOURCE_ATTRIBUTE,
-            ResourceDeclaration(
-                path=resource_path,
-                name=name or func.__name__,
-                scheme=scheme,
-                title=title,
-                description=description,
-                mime_type=mime_type,
-                file=_beside(func, file) if file is not None else None,
-            ),
+        return ResourceDeclaration(
+            path=resource_path,
+            name=name or func.__name__,
+            scheme=scheme,
+            title=title,
+            description=description or inspect.getdoc(func),
+            mime_type=mime_type,
+            file=_beside(func, file) if file is not None else None,
+            func=func,
         )
-        return func
 
     return decorator
 

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -14,7 +14,7 @@ import re
 import sys
 from bisect import bisect_right, insort
 from collections.abc import Callable, Iterator
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -170,35 +170,33 @@ class ResourceDeclaration:
         return self.func()
 
 
-def declared_contents(declaration: ResourceDeclaration) -> Any:
-    """Resolve a declaration's contents once: its file's, or what its function returns."""
+def _contents(declaration: ResourceDeclaration, mime_type: str | None) -> Any:
+    """A declaration's contents: its file's, read as text for a text media type, or its function's."""
     if declaration.file is not None:
-        if (declaration.mime_type or "").startswith("text/"):
+        if (mime_type or "").startswith("text/"):
             return declaration.file.read_text(encoding="utf-8")
         return declaration.file.read_bytes()
     return declaration()
 
 
-def as_interface(declaration: ResourceDeclaration) -> ResourceDeclaration:
-    """The declaration as a host needs it to render a tool's user interface.
+def _interface_mime_type(declaration: ResourceDeclaration) -> str:
+    """The media type a declaration is served under when a tool names it as its interface.
 
     A host renders only ``ui://`` documents of exactly one media type. A
-    declaration that leaves the media type unset gets it here. One that names
-    another cannot be rendered, and saying so at load beats a blank panel.
+    declaration that leaves the media type unset gets it. One that names another
+    cannot be rendered, and saying so at load beats a blank panel.
     """
     if declaration.scheme != UI_SCHEME:
         raise ValueError(
             f"resource {declaration.name!r} is declared under the {declaration.scheme!r} scheme, "
             f"and a user interface must be declared under {UI_SCHEME!r}"
         )
-    if declaration.mime_type is None:
-        return replace(declaration, mime_type=UI_DOCUMENT_MIME_TYPE)
-    if declaration.mime_type != UI_DOCUMENT_MIME_TYPE:
+    if declaration.mime_type not in (None, UI_DOCUMENT_MIME_TYPE):
         raise ValueError(
             f"resource {declaration.name!r} is declared as {declaration.mime_type!r}, and a host "
             f"renders a user interface only as {UI_DOCUMENT_MIME_TYPE!r}. Leave mime_type unset."
         )
-    return declaration
+    return UI_DOCUMENT_MIME_TYPE
 
 
 def _beside(func: Callable[..., Any], file: str) -> Path:
@@ -243,10 +241,11 @@ def resource(
             return render("draft-review.html")
 
     The docstring is the description unless one is given. A declaration a
-    tool passes as its ``ui`` is registered with that tool and needs no media
-    type. Any other declaration is found by scanning for the decorator at
-    module scope, so one inside a class body or nested in another function is
-    not found.
+    tool passes as its ``ui`` is registered with that tool, on every path a
+    tool is registered, and needs no media type. Any other declaration is
+    registered when its toolkit is loaded, found by scanning for the decorator
+    at module scope, so one inside a class body or nested in another function
+    is not found.
     """
 
     if path is None:
@@ -281,10 +280,11 @@ def resource(
 
 @dataclass(frozen=True)
 class RegisteredResource:
-    """A listing entry and the bytes it resolves to."""
+    """A listing entry, the bytes it resolves to, and the declaration it came from."""
 
     resource: Resource
     contents: TextResourceContents | BlobResourceContents
+    declaration: ResourceDeclaration | None = None
 
 
 class ResourceRegistry:
@@ -321,7 +321,16 @@ class ResourceRegistry:
         return (self._resources[uri] for uri in self._uris)
 
     def add(self, resource: Resource, contents: str | bytes) -> RegisteredResource:
-        """Register a resource at its own URI, replacing any resource already there.
+        """Register a resource at its own URI, replacing any resource already there."""
+        return self._store(resource, contents, declaration=None)
+
+    def _store(
+        self,
+        resource: Resource,
+        contents: str | bytes,
+        declaration: ResourceDeclaration | None,
+    ) -> RegisteredResource:
+        """Hold the resource and its resolved body at the resource's URI.
 
         Text and binary are kept apart by type rather than by emptiness, so a
         zero-length document and a zero-length blob stay distinguishable all the
@@ -356,7 +365,7 @@ class ResourceRegistry:
                 text=contents,
             )
 
-        registered = RegisteredResource(resource=resource, contents=body)
+        registered = RegisteredResource(resource=resource, contents=body, declaration=declaration)
         if resource.uri not in self._resources:
             insort(self._uris, resource.uri)
         self._resources[resource.uri] = registered
@@ -381,25 +390,46 @@ class ResourceRegistry:
     def declare(
         self,
         declaration: ResourceDeclaration,
-        contents: str | bytes,
         *,
         toolkit_name: str,
-        toolkit_version: str,
+        toolkit_version: str | None,
+        as_interface: bool = False,
     ) -> RegisteredResource:
-        """Register a toolkit's declaration, qualifying its URI on the way in.
+        """Resolve a declaration's contents and register it under the toolkit's URI.
 
         Qualification happens here because this is the only point where the
-        declaration and the toolkit's identity are both in scope.
+        declaration and the toolkit's identity are both in scope. The same
+        declaration reached twice, from two tools or from a tool and then the
+        module scan, is registered once. A different declaration at the same URI
+        raises, because two resources in one toolkit cannot share a path and this
+        is the only point where both are in scope. A declaration a tool names as
+        its interface is served under the media type a host requires.
         """
+        if toolkit_version is None:
+            raise ValueError(
+                f"resource {declaration.name!r} cannot be registered: the toolkit has no "
+                f"version, so no URI can be derived for it"
+            )
         uri = self.uri_for(declaration, toolkit_name=toolkit_name, toolkit_version=toolkit_version)
+
+        existing = self._resources.get(uri)
+        if existing is not None:
+            if existing.declaration is declaration:
+                return existing
+            raise ValueError(
+                f"{declaration.name!r} and {existing.resource.name!r} both declare {uri}. Two "
+                f"resources in one toolkit cannot share a path."
+            )
+
+        mime_type = _interface_mime_type(declaration) if as_interface else declaration.mime_type
         resource = Resource(
             uri=uri,
             name=declaration.name,
             title=declaration.title,
             description=declaration.description,
-            mimeType=declaration.mime_type,
+            mimeType=mime_type,
         )
-        return self.add(resource, contents)
+        return self._store(resource, _contents(declaration, mime_type), declaration=declaration)
 
     def get(self, uri: str) -> RegisteredResource:
         try:

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -15,6 +15,8 @@ import sys
 from bisect import bisect_right, insort
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
+from functools import cache
+from importlib.metadata import PackageNotFoundError, metadata
 from pathlib import Path
 from typing import Any
 from urllib.parse import quote
@@ -24,6 +26,7 @@ from arcade_core.resource_schema import (
     Resource,
     TextResourceContents,
 )
+from arcade_core.utils import normalize_toolkit_name, strip_arcade_prefix
 
 DEFAULT_PAGE_SIZE = 250
 
@@ -197,6 +200,64 @@ def _interface_mime_type(declaration: ResourceDeclaration) -> str:
             f"renders a user interface only as {UI_DOCUMENT_MIME_TYPE!r}. Leave mime_type unset."
         )
     return UI_DOCUMENT_MIME_TYPE
+
+
+@cache
+def _distribution_identity(package: str) -> tuple[str, str] | None:
+    """The toolkit name and version of the installed distribution shipping ``package``.
+
+    ``metadata`` rather than ``packages_distributions``: the latter reports
+    nothing for a package installed from source in a workspace, which is how
+    every toolkit under development is installed.
+    """
+    try:
+        found = metadata(package)
+    except PackageNotFoundError:
+        # Loose files on the path rather than an installed distribution, so
+        # there is no version to qualify with.
+        return None
+    name, version = found["Name"], found["Version"]
+    if not name or not version:
+        return None
+    return normalize_toolkit_name(strip_arcade_prefix(name.replace("-", "_"))), version
+
+
+def _origin(declaration: ResourceDeclaration) -> tuple[str, str] | None:
+    """The toolkit that ships a declaration, as opposed to whoever serves it."""
+    func = declaration.func
+    module = getattr(func, "__module__", None) if func is not None else None
+    if not module:
+        return None
+    return _distribution_identity(module.split(".")[0])
+
+
+def _declared_at(declaration: ResourceDeclaration | None) -> str:
+    """Where a declaration was written, for an error a reader has to act on."""
+    if declaration is None:
+        return "an unknown resource"
+    func = declaration.func
+    module = getattr(func, "__module__", None) if func is not None else None
+    return f"{module}.{declaration.name}" if module else repr(declaration.name)
+
+
+def interface_uri(
+    declaration: ResourceDeclaration,
+    *,
+    toolkit_name: str,
+    toolkit_version: str,
+) -> str:
+    """The URI a declaration is served under.
+
+    A document belongs to the package that ships it, not to the server that
+    happens to serve it. One server can compose tools from several installed
+    toolkits, and each toolkit names its own documents without seeing the
+    others, so qualifying by the composing server puts authors who cannot see
+    each other in one collision domain. The toolkit passed in is the fallback,
+    for a declaration whose package is not an installed distribution.
+    """
+    origin = _origin(declaration)
+    name, version = origin if origin is not None else (toolkit_name, toolkit_version)
+    return qualify(name, version, declaration.path, declaration.scheme)
 
 
 def _beside(func: Callable[..., Any], file: str) -> Path:
@@ -410,15 +471,15 @@ class ResourceRegistry:
                 f"resource {declaration.name!r} cannot be registered: the toolkit has no "
                 f"version, so no URI can be derived for it"
             )
-        uri = self.uri_for(declaration, toolkit_name=toolkit_name, toolkit_version=toolkit_version)
+        uri = interface_uri(declaration, toolkit_name=toolkit_name, toolkit_version=toolkit_version)
 
         existing = self._resources.get(uri)
         if existing is not None:
             if existing.declaration is declaration:
                 return existing
             raise ValueError(
-                f"{declaration.name!r} and {existing.resource.name!r} both declare {uri}. Two "
-                f"resources in one toolkit cannot share a path."
+                f"{_declared_at(declaration)} and {_declared_at(existing.declaration)} both "
+                f"declare {uri}. Two resources in one toolkit cannot share a path."
             )
 
         mime_type = _interface_mime_type(declaration) if as_interface else declaration.mime_type

--- a/libs/arcade-core/arcade_core/schema.py
+++ b/libs/arcade-core/arcade_core/schema.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal, Protocol
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from arcade_core.errors import ErrorKind
 from arcade_core.metadata import ToolMetadata
@@ -339,6 +339,13 @@ class ToolDefinition(BaseModel):
 
     metadata: ToolMetadata | None = None
     """Metadata about the tool"""
+
+    meta: dict[str, Any] | None = Field(default=None, alias="_meta")
+    """Out-of-band data attached to the tool, carried through untouched."""
+
+    # Without this a ``meta=`` keyword is silently ignored, and a dump-then-validate
+    # round trip drops the field with no error.
+    model_config = ConfigDict(populate_by_name=True)
 
     def get_fully_qualified_name(self) -> FullyQualifiedName:
         return FullyQualifiedName(self.name, self.toolkit.name, self.toolkit.version)

--- a/libs/arcade-core/arcade_core/toolkit.py
+++ b/libs/arcade-core/arcade_core/toolkit.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 from arcade_core.errors import ToolkitLoadError
 from arcade_core.parse import get_resources_from_ast, get_tools_from_ast, load_ast_tree
+from arcade_core.utils import strip_arcade_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -56,9 +57,7 @@ class Toolkit(BaseModel):
         """
         Strip the 'arcade_' prefix from the name if it exists.
         """
-        if value.startswith("arcade_"):
-            return value[len("arcade_") :]
-        return value
+        return strip_arcade_prefix(value)
 
     @classmethod
     def from_module(cls, module: types.ModuleType) -> "Toolkit":

--- a/libs/arcade-core/arcade_core/utils.py
+++ b/libs/arcade-core/arcade_core/utils.py
@@ -36,6 +36,13 @@ def space_to_snake_case(name: str) -> str:
     return name.replace(" ", "_")
 
 
+def strip_arcade_prefix(name: str) -> str:
+    """A distribution named ``arcade_math`` ships the toolkit ``math``."""
+    if name.startswith("arcade_"):
+        return name[len("arcade_") :]
+    return name
+
+
 def normalize_toolkit_name(name: str) -> str:
     """The toolkit name as everything downstream of a toolkit sees it.
 

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.16.0"
+version = "4.17.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-mcp-server/arcade_mcp_server/__init__.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/__init__.py
@@ -10,7 +10,7 @@ This package provides:
 - Context system for tool execution with MCP methods
 """
 
-from arcade_core.resources import ResourceDeclaration, resource
+from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, ResourceDeclaration, resource
 
 from arcade_mcp_server.context import Context
 from arcade_mcp_server.decorators import tool
@@ -78,6 +78,7 @@ __all__ = [
     "UntitledMultiSelectEnumSchema",
     "UntitledSingleSelectEnumSchema",
     "create_arcade_mcp",
+    "UI_DOCUMENT_MIME_TYPE",
     "resource",
     "run_arcade_mcp",
     "tool",

--- a/libs/arcade-mcp-server/arcade_mcp_server/__init__.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/__init__.py
@@ -10,7 +10,7 @@ This package provides:
 - Context system for tool execution with MCP methods
 """
 
-from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, ResourceDeclaration, resource
+from arcade_core.resources import ResourceDeclaration, resource
 
 from arcade_mcp_server.context import Context
 from arcade_mcp_server.decorators import tool
@@ -78,7 +78,6 @@ __all__ = [
     "UntitledMultiSelectEnumSchema",
     "UntitledSingleSelectEnumSchema",
     "create_arcade_mcp",
-    "UI_DOCUMENT_MIME_TYPE",
     "resource",
     "run_arcade_mcp",
     "tool",

--- a/libs/arcade-mcp-server/arcade_mcp_server/convert.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/convert.py
@@ -92,9 +92,10 @@ def create_mcp_tool(materialized_tool: MaterializedTool) -> MCPTool:
         raw_execution if isinstance(raw_execution, ToolExecution) else None
     )
 
-    # Build _meta.arcade structure
+    meta: dict[str, Any] = dict(definition.meta or {})
     arcade_meta = _build_arcade_meta(definition)
-    meta = {"arcade": arcade_meta} if arcade_meta else None
+    if arcade_meta:
+        meta["arcade"] = arcade_meta
 
     return MCPTool(
         name=name,
@@ -104,7 +105,7 @@ def create_mcp_tool(materialized_tool: MaterializedTool) -> MCPTool:
         outputSchema=output_schema if output_schema else None,
         annotations=annotations,
         execution=mcp_execution,
-        _meta=meta,
+        _meta=meta or None,
     )
 
 

--- a/libs/arcade-mcp-server/arcade_mcp_server/decorators.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/decorators.py
@@ -32,6 +32,7 @@ def tool(
     requires_metadata: list[str] | None = None,
     adapters: list[ErrorAdapter] | None = None,
     metadata: ToolMetadata | None = None,
+    ui: str | None = None,
     execution: ToolExecution | None = None,
 ) -> Callable:
     """MCP-aware ``@tool`` decorator.
@@ -54,6 +55,7 @@ def tool(
             requires_metadata=requires_metadata,
             adapters=adapters,
             metadata=metadata,
+            ui=ui,
         )
         # Write on the error-handler-wrapped callable arcade-tdk returns.
         # Both read sites (``server.py`` for taskSupport policy and

--- a/libs/arcade-mcp-server/arcade_mcp_server/decorators.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/decorators.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import Callable
 
 from arcade_core.metadata import ToolMetadata
+from arcade_core.resources import ResourceDeclaration
 from arcade_tdk import tool as _arcade_tdk_tool
 from arcade_tdk.auth import ToolAuthorization
 from arcade_tdk.error_adapters import ErrorAdapter
@@ -32,7 +33,7 @@ def tool(
     requires_metadata: list[str] | None = None,
     adapters: list[ErrorAdapter] | None = None,
     metadata: ToolMetadata | None = None,
-    ui: str | None = None,
+    ui: ResourceDeclaration | None = None,
     execution: ToolExecution | None = None,
 ) -> Callable:
     """MCP-aware ``@tool`` decorator.

--- a/libs/arcade-mcp-server/arcade_mcp_server/managers/resource.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/managers/resource.py
@@ -13,6 +13,9 @@ import re
 from pathlib import Path
 from typing import Any, Callable, Literal
 
+from arcade_core.catalog import ToolCatalog
+from arcade_core.resource_schema import TextResourceContents as CatalogTextContents
+
 from arcade_mcp_server.exceptions import NotFoundError, ResourceError
 from arcade_mcp_server.managers.base import ComponentManager
 from arcade_mcp_server.types import (
@@ -78,6 +81,15 @@ def make_text_handler(text: str) -> Callable[[str], str]:
     return handler
 
 
+def make_static_handler(body: str | bytes) -> Callable[[str], str | bytes]:
+    """Create a handler that returns a body resolved ahead of time."""
+
+    def handler(_uri: str) -> str | bytes:
+        return body
+
+    return handler
+
+
 def make_file_handler(path: str | Path) -> Callable[[str], str | bytes]:
     """Create a handler that reads a file, returning text or bytes."""
     file_path = Path(path)
@@ -110,6 +122,20 @@ class ResourceManager(ComponentManager[str, Resource]):
         self._template_patterns: dict[str, re.Pattern[str]] = {}
         self.duplicate_policy: DuplicatePolicy = duplicate_policy
         self.multiple_match_policy: MultipleMatchPolicy = multiple_match_policy
+
+    async def load_from_catalog(self, catalog: ToolCatalog) -> None:
+        """Serve every resource the catalog's toolkits declared."""
+        for registered in catalog.resources:
+            resource = Resource.model_validate(
+                registered.resource.model_dump(by_alias=True, exclude_none=True)
+            )
+            contents = registered.contents
+            body: str | bytes = (
+                contents.text
+                if isinstance(contents, CatalogTextContents)
+                else base64.b64decode(contents.blob)
+            )
+            await self.add_resource(resource, handler=make_static_handler(body))
 
     async def list_resources(self) -> list[Resource]:
         return await self.registry.list()

--- a/libs/arcade-mcp-server/arcade_mcp_server/mcp_app.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/mcp_app.py
@@ -341,14 +341,14 @@ class MCPApp:
                 ui=ui,
                 execution=execution,
             )
-        elif execution is not None:
-            # Pre-decorated tool with an explicit ``execution=`` at registration
-            # time: write the dunder directly. The catalog reads it off the
-            # decorated callable (`MCPServer._handle_call_tool` and
-            # `convert.create_mcp_tool` both `getattr(..., "__tool_execution__")`).
-            func.__tool_execution__ = execution  # type: ignore[attr-defined]
-        if ui is not None and getattr(func, "__tool_ui__", None) is not ui:
-            func.__tool_ui__ = ui  # type: ignore[union-attr]
+        else:
+            # A pre-decorated tool with ``execution=`` or ``ui=`` given here as
+            # well: write the dunders directly. The catalog reads both off the
+            # decorated callable.
+            if execution is not None:
+                func.__tool_execution__ = execution  # type: ignore[attr-defined]
+            if ui is not None:
+                func.__tool_ui__ = ui  # type: ignore[attr-defined]
         try:
             self._catalog.add_tool(
                 func,
@@ -534,9 +534,10 @@ class MCPApp:
     def _warn_unregistered_resource_declarations(self) -> None:
         """Report @resource declarations this app never registered.
 
-        @resource marks a function, and the mark is read when a toolkit is added
-        to the catalog. An app assembled from @app.tool alone never gets there,
-        so without this the decorator imports, runs and registers nothing.
+        A declaration is registered when a toolkit is added to the catalog or
+        when a tool names it as its ``ui``. An app assembled from @app.tool
+        alone, with declarations no tool names, never gets there, so without
+        this the decorator imports, runs and registers nothing.
         """
         if len(self._catalog.resources) > 0:
             return
@@ -558,8 +559,9 @@ class MCPApp:
         logger.warning(
             f"{where} declares {len(declared)} resource(s) "
             f"({', '.join(declared)}) that this app does not register. "
-            f"@resource is read when a toolkit is added to the catalog. Use "
-            f"app.add_tools_from_module(...), or @app.resource to register one directly."
+            f"A declaration is registered when a toolkit is added to the catalog or when a "
+            f"tool names it as its ui. Pass it to a tool as ui=, use "
+            f"app.add_tools_from_module(...), or use @app.resource to register one directly."
         )
 
     def run(

--- a/libs/arcade-mcp-server/arcade_mcp_server/mcp_app.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/mcp_app.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Literal, ParamSpec, TypeVar, cast
 
 from arcade_core.catalog import MaterializedTool, ToolCatalog, ToolDefinitionError
 from arcade_core.metadata import ToolMetadata
-from arcade_core.resources import RESOURCE_ATTRIBUTE
+from arcade_core.resources import ResourceDeclaration
 from arcade_core.subprocess_utils import (
     get_windows_no_window_creationflags,
     graceful_terminate_process,
@@ -313,6 +313,7 @@ class MCPApp:
         adapters: list[ErrorAdapter] | None = None,
         metadata: ToolMetadata | None = None,
         meta: dict[str, Any] | None = None,
+        ui: ResourceDeclaration | None = None,
         execution: ToolExecution | None = None,
     ) -> Callable[P, T]:
         """Add a tool for build-time materialization (pre-server).
@@ -337,6 +338,7 @@ class MCPApp:
                 requires_metadata=requires_metadata,
                 adapters=adapters,
                 metadata=metadata,
+                ui=ui,
                 execution=execution,
             )
         elif execution is not None:
@@ -345,6 +347,8 @@ class MCPApp:
             # decorated callable (`MCPServer._handle_call_tool` and
             # `convert.create_mcp_tool` both `getattr(..., "__tool_execution__")`).
             func.__tool_execution__ = execution  # type: ignore[attr-defined]
+        if ui is not None and getattr(func, "__tool_ui__", None) is not ui:
+            func.__tool_ui__ = ui  # type: ignore[union-attr]
         try:
             self._catalog.add_tool(
                 func,
@@ -498,6 +502,7 @@ class MCPApp:
         adapters: list[ErrorAdapter] | None = None,
         metadata: ToolMetadata | None = None,
         meta: dict[str, Any] | None = None,
+        ui: ResourceDeclaration | None = None,
         execution: ToolExecution | None = None,
     ) -> Callable[[Callable[P, T]], Callable[P, T]] | Callable[P, T]:
         """Decorator for adding tools with optional parameters.
@@ -517,6 +522,7 @@ class MCPApp:
                 requires_metadata=requires_metadata,
                 adapters=adapters,
                 metadata=metadata,
+                ui=ui,
                 meta=meta,
                 execution=execution,
             )
@@ -543,9 +549,7 @@ class MCPApp:
             return
 
         declared = [
-            name
-            for name, value in vars(module).items()
-            if getattr(value, RESOURCE_ATTRIBUTE, None) is not None
+            name for name, value in vars(module).items() if isinstance(value, ResourceDeclaration)
         ]
         if not declared:
             return

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -602,10 +602,7 @@ class MCPServer:
         await self._check_and_warn_missing_secrets()
 
         await self._resource_manager.start()
-        try:
-            await self._resource_manager.load_from_catalog(self._initial_catalog)
-        except Exception:
-            logger.exception("Failed to load resources from initial catalog")
+        await self._resource_manager.load_from_catalog(self._initial_catalog)
         for item, handler in self._initial_resources:
             if isinstance(item, ResourceTemplate):
                 if handler is not None:

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -602,6 +602,10 @@ class MCPServer:
         await self._check_and_warn_missing_secrets()
 
         await self._resource_manager.start()
+        try:
+            await self._resource_manager.load_from_catalog(self._initial_catalog)
+        except Exception:
+            logger.exception("Failed to load resources from initial catalog")
         for item, handler in self._initial_resources:
             if isinstance(item, ResourceTemplate):
                 if handler is not None:

--- a/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
@@ -111,10 +111,11 @@ def _validate_origin(request: Request, allowed_origins: list[str] | None) -> Res
     return None
 
 
+# A response may carry only one allow-origin value, so anything an earlier layer
+# set is replaced rather than joined. Vary may repeat, so it is only added.
 _CORS_HEADERS_SET_HERE = frozenset({
     b"access-control-allow-origin",
     b"access-control-expose-headers",
-    b"vary",
 })
 
 

--- a/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
@@ -111,12 +111,23 @@ def _validate_origin(request: Request, allowed_origins: list[str] | None) -> Res
     return None
 
 
+_CORS_HEADERS_SET_HERE = frozenset({
+    b"access-control-allow-origin",
+    b"access-control-expose-headers",
+    b"vary",
+})
+
+
 def _with_cors_headers(send: Send, origin: str) -> Send:
     """Wrap an ASGI send so the response start carries the CORS headers for ``origin``."""
 
     async def send_with_cors(message: Message) -> None:
         if message["type"] == "http.response.start":
-            headers = list(message.get("headers", []))
+            headers = [
+                (name, value)
+                for name, value in message.get("headers", [])
+                if name.lower() not in _CORS_HEADERS_SET_HERE
+            ]
             headers.append((b"access-control-allow-origin", origin.encode("latin-1")))
             headers.append((
                 b"access-control-expose-headers",

--- a/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/transports/http_session_manager.py
@@ -15,7 +15,7 @@ import anyio
 from anyio.abc import TaskStatus
 from starlette.requests import Request
 from starlette.responses import Response
-from starlette.types import Receive, Scope, Send
+from starlette.types import Message, Receive, Scope, Send
 
 from arcade_mcp_server.server import MCPServer
 from arcade_mcp_server.session import InitializationState, ServerSession
@@ -109,6 +109,24 @@ def _validate_origin(request: Request, allowed_origins: list[str] | None) -> Res
         )
 
     return None
+
+
+def _with_cors_headers(send: Send, origin: str) -> Send:
+    """Wrap an ASGI send so the response start carries the CORS headers for ``origin``."""
+
+    async def send_with_cors(message: Message) -> None:
+        if message["type"] == "http.response.start":
+            headers = list(message.get("headers", []))
+            headers.append((b"access-control-allow-origin", origin.encode("latin-1")))
+            headers.append((
+                b"access-control-expose-headers",
+                b"Mcp-Session-Id, MCP-Protocol-Version",
+            ))
+            headers.append((b"vary", b"Origin"))
+            message = {**message, "headers": headers}
+        await send(message)
+
+    return send_with_cors
 
 
 def _validate_accept_header(request: Request) -> Response | None:
@@ -295,6 +313,13 @@ class HTTPSessionManager:
         if origin_error is not None:
             await origin_error(scope, receive, send)
             return
+
+        # A browser only lets the page read a cross-origin response that names
+        # its origin, so an allowed Origin is echoed on every response, not
+        # only on the preflight.
+        origin = request.headers.get("origin")
+        if origin is not None:
+            send = _with_cors_headers(send, origin)
 
         # --- Handle OPTIONS (CORS preflight) ---
         if request.method == "OPTIONS":

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.28.1"
+version = "1.29.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,9 +21,9 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.16.0,<5.0.0",
+    "arcade-core>=4.17.0,<5.0.0",
     "arcade-serve>=3.6.0,<4.0.0",
-    "arcade-tdk>=3.11.0,<4.0.0",
+    "arcade-tdk>=3.12.0,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",
     "fastapi>=0.100.0",

--- a/libs/arcade-tdk/arcade_tdk/__init__.py
+++ b/libs/arcade-tdk/arcade_tdk/__init__.py
@@ -1,5 +1,5 @@
 from arcade_core.catalog import ToolCatalog
-from arcade_core.resources import ResourceDeclaration, resource
+from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, ResourceDeclaration, resource
 from arcade_core.schema import (
     ToolAuthorizationContext,
     ToolContext,
@@ -20,6 +20,7 @@ __all__ = [
     "ToolMetadataKey",
     "ToolSecretItem",
     "Toolkit",
+    "UI_DOCUMENT_MIME_TYPE",
     "resource",
     "tool",
 ]

--- a/libs/arcade-tdk/arcade_tdk/__init__.py
+++ b/libs/arcade-tdk/arcade_tdk/__init__.py
@@ -1,5 +1,5 @@
 from arcade_core.catalog import ToolCatalog
-from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, ResourceDeclaration, resource
+from arcade_core.resources import ResourceDeclaration, resource
 from arcade_core.schema import (
     ToolAuthorizationContext,
     ToolContext,
@@ -20,7 +20,6 @@ __all__ = [
     "ToolMetadataKey",
     "ToolSecretItem",
     "Toolkit",
-    "UI_DOCUMENT_MIME_TYPE",
     "resource",
     "tool",
 ]

--- a/libs/arcade-tdk/arcade_tdk/tool.py
+++ b/libs/arcade-tdk/arcade_tdk/tool.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any, Callable, TypeVar
 
 from arcade_core.metadata import ToolMetadata
+from arcade_core.resources import ResourceDeclaration
 
 from arcade_tdk.auth import ToolAuthorization
 from arcade_tdk.error_adapters import ErrorAdapter
@@ -139,18 +140,24 @@ def tool(
     requires_metadata: list[str] | None = None,
     adapters: list[ErrorAdapter] | None = None,
     metadata: ToolMetadata | None = None,
-    ui: str | None = None,
+    ui: ResourceDeclaration | None = None,
 ) -> Callable:
     """Mark a function as a tool.
 
-    ``ui`` names the tool's user interface: the path of a resource this same
-    toolkit declares with ``@resource``. It is resolved to that resource's full
-    URI when the toolkit is registered, so the two cannot drift apart.
+    ``ui`` is the resource a host renders as this tool's user interface: import
+    the declaration ``@resource`` returns and pass it. The resource is registered
+    with the tool, and both are qualified into one URI at that point.
     """
 
     def decorator(func: Callable) -> Callable:
         func_name = str(getattr(func, "__name__", None))
         tool_name = name or snake_to_pascal_case(func_name)
+
+        if ui is not None and not isinstance(ui, ResourceDeclaration):
+            raise TypeError(
+                f"Tool '{tool_name}': ui expects the declaration @resource returns, "
+                f"got {type(ui).__name__}."
+            )
 
         func.__tool_name__ = tool_name  # type: ignore[attr-defined]
         func.__tool_description__ = desc or inspect.cleandoc(func.__doc__ or "")  # type: ignore[attr-defined]

--- a/libs/arcade-tdk/arcade_tdk/tool.py
+++ b/libs/arcade-tdk/arcade_tdk/tool.py
@@ -139,7 +139,15 @@ def tool(
     requires_metadata: list[str] | None = None,
     adapters: list[ErrorAdapter] | None = None,
     metadata: ToolMetadata | None = None,
+    ui: str | None = None,
 ) -> Callable:
+    """Mark a function as a tool.
+
+    ``ui`` names the tool's user interface: the path of a resource this same
+    toolkit declares with ``@resource``. It is resolved to that resource's full
+    URI when the toolkit is registered, so the two cannot drift apart.
+    """
+
     def decorator(func: Callable) -> Callable:
         func_name = str(getattr(func, "__name__", None))
         tool_name = name or snake_to_pascal_case(func_name)
@@ -150,6 +158,7 @@ def tool(
         func.__tool_requires_secrets__ = requires_secrets  # type: ignore[attr-defined]
         func.__tool_requires_metadata__ = requires_metadata  # type: ignore[attr-defined]
         func.__tool_metadata__ = metadata  # type: ignore[attr-defined]
+        func.__tool_ui__ = ui  # type: ignore[attr-defined]
 
         adapter_chain = _build_adapter_chain(adapters, requires_auth)
 

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "3.11.1"
+version = "3.12.0"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = { text = "MIT" }
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
-dependencies = ["arcade-core>=4.16.0,<5.0.0", "pydantic>=2.7.0"]
+dependencies = ["arcade-core>=4.17.0,<5.0.0", "pydantic>=2.7.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/libs/tests/arcade_mcp_server/test_app_tool_ui.py
+++ b/libs/tests/arcade_mcp_server/test_app_tool_ui.py
@@ -1,0 +1,21 @@
+"""A tool added to an app carries its interface with it, the same as in a toolkit."""
+
+from arcade_mcp_server import MCPApp, resource
+
+
+def test_a_tool_added_to_an_app_registers_its_interface():
+    @resource(path="dashboard.html")
+    def dashboard() -> str:
+        return "<!DOCTYPE html><p>dashboard</p>"
+
+    app = MCPApp(name="widgets", version="1.0.0")
+
+    @app.tool(ui=dashboard)
+    def show() -> str:
+        """Show a dashboard."""
+        return ""
+
+    registered = app._catalog.resources.get("ui://Widgets/1.0.0/dashboard.html")
+
+    assert registered.resource.mimeType == "text/html;profile=mcp-app"
+    assert show.__tool_ui__ is dashboard

--- a/libs/tests/arcade_mcp_server/test_http_transport.py
+++ b/libs/tests/arcade_mcp_server/test_http_transport.py
@@ -16,6 +16,7 @@ from arcade_mcp_server.transports.http_session_manager import (
     _replay_receive,
     _validate_accept_header,
     _validate_origin,
+    _with_cors_headers,
     _validate_protocol_version_header,
 )
 from arcade_mcp_server.transports.http_streamable import HTTPStreamableTransport
@@ -289,3 +290,29 @@ class TestParseErrorNullId:
         # Should parse successfully or use None for id
         if isinstance(result, JSONRPCError):
             assert result.id is None or isinstance(result.id, (str, int))
+
+
+class TestCorsHeadersOnResponses:
+    """An allowed Origin is echoed on the response itself, not only on the preflight."""
+
+    @pytest.mark.asyncio
+    async def test_response_start_carries_the_origin(self):
+        sent: list[dict] = []
+
+        async def send(message):
+            sent.append(message)
+
+        wrapped = _with_cors_headers(send, "https://example.com")
+        await wrapped({
+            "type": "http.response.start",
+            "status": 200,
+            "headers": [(b"content-type", b"application/json")],
+        })
+        await wrapped({"type": "http.response.body", "body": b"{}"})
+
+        headers = dict(sent[0]["headers"])
+        assert headers[b"content-type"] == b"application/json"
+        assert headers[b"access-control-allow-origin"] == b"https://example.com"
+        assert headers[b"access-control-expose-headers"] == b"Mcp-Session-Id, MCP-Protocol-Version"
+        assert headers[b"vary"] == b"Origin"
+        assert sent[1] == {"type": "http.response.body", "body": b"{}"}

--- a/libs/tests/arcade_mcp_server/test_http_transport.py
+++ b/libs/tests/arcade_mcp_server/test_http_transport.py
@@ -316,3 +316,24 @@ class TestCorsHeadersOnResponses:
         assert headers[b"access-control-expose-headers"] == b"Mcp-Session-Id, MCP-Protocol-Version"
         assert headers[b"vary"] == b"Origin"
         assert sent[1] == {"type": "http.response.body", "body": b"{}"}
+
+    @pytest.mark.asyncio
+    async def test_a_preflight_that_already_answered_gets_one_origin_value(self):
+        sent: list[dict] = []
+
+        async def send(message):
+            sent.append(message)
+
+        wrapped = _with_cors_headers(send, "https://example.com")
+        await wrapped({
+            "type": "http.response.start",
+            "status": 204,
+            "headers": [
+                (b"access-control-allow-origin", b"*"),
+                (b"access-control-max-age", b"86400"),
+            ],
+        })
+
+        values = [v for k, v in sent[0]["headers"] if k == b"access-control-allow-origin"]
+        assert values == [b"https://example.com"]
+        assert (b"access-control-max-age", b"86400") in sent[0]["headers"]

--- a/libs/tests/arcade_mcp_server/test_resource.py
+++ b/libs/tests/arcade_mcp_server/test_resource.py
@@ -715,9 +715,11 @@ async def test_load_from_catalog_serves_a_declared_document():
     catalog = ToolCatalog()
     catalog.resources.declare(
         ResourceDeclaration(
-            path="dashboard.html", name="dashboard", mime_type="text/html;profile=example"
+            path="dashboard.html",
+            name="dashboard",
+            mime_type="text/html;profile=example",
+            func=lambda: "<!DOCTYPE html><p>hi</p>",
         ),
-        "<!DOCTYPE html><p>hi</p>",
         toolkit_name="Kit",
         toolkit_version="1.0.0",
     )
@@ -742,8 +744,9 @@ async def test_load_from_catalog_serves_a_declared_blob():
 
     catalog = ToolCatalog()
     catalog.resources.declare(
-        ResourceDeclaration(path="icon.png", name="icon", mime_type="image/png"),
-        b"\x89PNG\r\n",
+        ResourceDeclaration(
+            path="icon.png", name="icon", mime_type="image/png", func=lambda: b"\x89PNG\r\n"
+        ),
         toolkit_name="Kit",
         toolkit_version="1.0.0",
     )

--- a/libs/tests/arcade_mcp_server/test_resource.py
+++ b/libs/tests/arcade_mcp_server/test_resource.py
@@ -705,3 +705,54 @@ class TestMultipleMatchPolicy:
 
         assert result[0].text == "weather-london"
         assert "matched" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_load_from_catalog_serves_a_declared_document():
+    from arcade_core.catalog import ToolCatalog
+    from arcade_core.resources import ResourceDeclaration
+
+    catalog = ToolCatalog()
+    catalog.resources.declare(
+        ResourceDeclaration(
+            path="dashboard.html", name="dashboard", mime_type="text/html;profile=example"
+        ),
+        "<!DOCTYPE html><p>hi</p>",
+        toolkit_name="Kit",
+        toolkit_version="1.0.0",
+    )
+    manager = ResourceManager()
+    await manager.start()
+
+    await manager.load_from_catalog(catalog)
+
+    listed = await manager.list_resources()
+    assert [r.uri for r in listed] == ["ui://Kit/1.0.0/dashboard.html"]
+    assert listed[0].mimeType == "text/html;profile=example"
+    contents = await manager.read_resource("ui://Kit/1.0.0/dashboard.html")
+    assert isinstance(contents[0], TextResourceContents)
+    assert contents[0].text == "<!DOCTYPE html><p>hi</p>"
+    assert contents[0].mimeType == "text/html;profile=example"
+
+
+@pytest.mark.asyncio
+async def test_load_from_catalog_serves_a_declared_blob():
+    from arcade_core.catalog import ToolCatalog
+    from arcade_core.resources import ResourceDeclaration
+
+    catalog = ToolCatalog()
+    catalog.resources.declare(
+        ResourceDeclaration(path="icon.png", name="icon", mime_type="image/png"),
+        b"\x89PNG\r\n",
+        toolkit_name="Kit",
+        toolkit_version="1.0.0",
+    )
+    manager = ResourceManager()
+    await manager.start()
+
+    await manager.load_from_catalog(catalog)
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/icon.png")
+    assert isinstance(contents[0], BlobResourceContents)
+    assert base64.b64decode(contents[0].blob) == b"\x89PNG\r\n"
+    assert contents[0].mimeType == "image/png"

--- a/libs/tests/arcade_mcp_server/test_tool_metadata_serialization.py
+++ b/libs/tests/arcade_mcp_server/test_tool_metadata_serialization.py
@@ -9,9 +9,15 @@ from arcade_core.metadata import (
     ServiceDomain,
     ToolMetadata,
 )
+from arcade_core.resources import resource
 from arcade_mcp_server.managers.tool import ToolManager
 from arcade_tdk import tool
 from arcade_tdk.auth import OAuth2
+
+
+@resource(path="dashboard.html")
+def dashboard() -> str:
+    return "<!DOCTYPE html><p>dashboard</p>"
 
 
 class TestToolMetadataSerialization:
@@ -374,7 +380,7 @@ class TestToolMetadataSerialization:
     def test_meta_includes_ui_resource_uri(self, tool_manager: ToolManager):
         """_meta.ui.resourceUri should point at the tool's user interface."""
 
-        @tool(desc="Tool with a user interface", ui="dashboard.html")
+        @tool(desc="Tool with a user interface", ui=dashboard)
         def show_dashboard() -> str:
             """Show the dashboard."""
             return "shown"
@@ -390,7 +396,7 @@ class TestToolMetadataSerialization:
 
         @tool(
             desc="Tool with a user interface and behavior metadata",
-            ui="dashboard.html",
+            ui=dashboard,
             metadata=ToolMetadata(
                 behavior=Behavior(
                     read_only=True,

--- a/libs/tests/arcade_mcp_server/test_tool_metadata_serialization.py
+++ b/libs/tests/arcade_mcp_server/test_tool_metadata_serialization.py
@@ -370,3 +370,57 @@ class TestToolMetadataSerialization:
         assert metadata["behavior"]["destructive"] is False
         assert metadata["behavior"]["open_world"] is True
         assert metadata["extras"] == {"idp": "google"}
+
+    def test_meta_includes_ui_resource_uri(self, tool_manager: ToolManager):
+        """_meta.ui.resourceUri should point at the tool's user interface."""
+
+        @tool(desc="Tool with a user interface", ui="dashboard.html")
+        def show_dashboard() -> str:
+            """Show the dashboard."""
+            return "shown"
+
+        materialized = self._create_materialized_tool(show_dashboard)
+        dto = tool_manager._to_dto(materialized)
+
+        assert dto.meta is not None
+        assert dto.meta["ui"]["resourceUri"] == "ui://Test/1.0.0/dashboard.html"
+
+    def test_meta_ui_and_arcade_coexist(self, tool_manager: ToolManager):
+        """_meta should carry both the ui pointer and the arcade namespace."""
+
+        @tool(
+            desc="Tool with a user interface and behavior metadata",
+            ui="dashboard.html",
+            metadata=ToolMetadata(
+                behavior=Behavior(
+                    read_only=True,
+                    destructive=False,
+                    idempotent=True,
+                    open_world=False,
+                ),
+            ),
+        )
+        def show_dashboard() -> str:
+            """Show the dashboard."""
+            return "shown"
+
+        materialized = self._create_materialized_tool(show_dashboard)
+        dto = tool_manager._to_dto(materialized)
+
+        assert dto.meta is not None
+        assert dto.meta["ui"]["resourceUri"] == "ui://Test/1.0.0/dashboard.html"
+        assert dto.meta["arcade"]["metadata"]["behavior"]["read_only"] is True
+        assert dto.meta["arcade"]["metadata"]["behavior"]["idempotent"] is True
+
+    def test_meta_is_none_without_ui_or_arcade_metadata(self, tool_manager: ToolManager):
+        """_meta should be None when a tool has neither a ui pointer nor Arcade metadata."""
+
+        @tool(desc="Plain tool")
+        def plain_tool() -> str:
+            """Plain tool."""
+            return "plain"
+
+        materialized = self._create_materialized_tool(plain_tool)
+        dto = tool_manager._to_dto(materialized)
+
+        assert dto.meta is None

--- a/libs/tests/core/test_interface_uri_origin.py
+++ b/libs/tests/core/test_interface_uri_origin.py
@@ -1,0 +1,201 @@
+"""A document is addressed by the package that ships it, not by the server serving it.
+
+One server can compose tools from several installed toolkits, and each toolkit
+names its own documents without seeing the others. Qualifying by the composing
+server puts authors who cannot see each other in one collision domain, so two
+toolkits that both ship ``panel.html`` take the whole server down.
+"""
+
+import importlib
+import sys
+import textwrap
+
+import pytest
+from arcade_core.catalog import ToolCatalog
+from arcade_core.errors import ToolkitLoadError
+from arcade_core.resources import _distribution_identity
+from arcade_core.toolkit import Toolkit
+
+UI_MODULE = '''
+from arcade_core.resources import resource
+
+
+@resource(file="panel.html")
+def show_panel_ui() -> None:
+    """The panel."""
+'''
+
+TOOLS_MODULE = '''
+from typing import Annotated
+
+from arcade_tdk import tool
+
+from {package}.ui import show_panel_ui
+
+
+@tool(ui=show_panel_ui, name="{tool_name}")
+def show_panel() -> Annotated[str, "a note"]:
+    """Show the panel."""
+    return "shown"
+'''
+
+TWO_AT_ONE_PATH = """
+from arcade_core.resources import resource
+
+
+@resource(path="panel.html", name="first")
+def first() -> str:
+    return "<!DOCTYPE html><p>first</p>"
+
+
+@resource(path="panel.html", name="second")
+def second() -> str:
+    return "<!DOCTYPE html><p>second</p>"
+"""
+
+
+@pytest.fixture
+def build_package(tmp_path, monkeypatch):
+    """Write an importable package, optionally as an installed distribution.
+
+    ``importlib.metadata`` reads ``*.dist-info/METADATA`` off ``sys.path``, so
+    writing one is what makes a package look installed to origin resolution.
+    """
+    built: list[str] = []
+
+    def build(package, version=None, tool_name="ShowPanel", ui_source=UI_MODULE):
+        root = tmp_path / package
+        pkg = root / package
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (pkg / "panel.html").write_text(f"<!DOCTYPE html><p>{package}</p>", encoding="utf-8")
+        (pkg / "ui.py").write_text(textwrap.dedent(ui_source), encoding="utf-8")
+        (pkg / "tools.py").write_text(
+            textwrap.dedent(TOOLS_MODULE).format(package=package, tool_name=tool_name),
+            encoding="utf-8",
+        )
+        (root / "pyproject.toml").write_text(
+            f'[project]\nname = "{package}"\nversion = "{version or "0.0.0"}"\n', encoding="utf-8"
+        )
+        if version is not None:
+            dist = root / f"{package}-{version}.dist-info"
+            dist.mkdir()
+            (dist / "METADATA").write_text(
+                f"Metadata-Version: 2.1\nName: {package}\nVersion: {version}\n", encoding="utf-8"
+            )
+        monkeypatch.syspath_prepend(str(root))
+        built.append(package)
+        _forget(package)
+        return root
+
+    yield build
+    for package in built:
+        _forget(package)
+    _distribution_identity.cache_clear()
+
+
+def _forget(package):
+    for name in [n for n in sys.modules if n == package or n.startswith(package + ".")]:
+        del sys.modules[name]
+
+
+@pytest.fixture(autouse=True)
+def _clear_origin_cache():
+    _distribution_identity.cache_clear()
+    yield
+    _distribution_identity.cache_clear()
+
+
+def _pointed(definition):
+    """The interface URI a tool's out-of-band data names."""
+    return definition.meta["ui"]["resourceUri"]
+
+
+def _tool(package):
+    return importlib.import_module(f"{package}.tools").show_panel
+
+
+def _compose(catalog, *packages):
+    """Add tools to one catalog under one server identity, as MCPApp does."""
+    for package in packages:
+        catalog.add_tool(_tool(package), "Combined", toolkit_version="1.0.0")
+
+
+def test_two_toolkits_sharing_a_document_path_do_not_collide(build_package):
+    build_package("arcade_alpha", version="2.0.0", tool_name="ShowPanelAlpha")
+    build_package("arcade_beta", version="3.1.0", tool_name="ShowPanelBeta")
+
+    catalog = ToolCatalog()
+    _compose(catalog, "arcade_alpha", "arcade_beta")
+
+    assert len(catalog) == 2
+    assert [registered.resource.uri for registered in catalog.resources] == [
+        "ui://Alpha/2.0.0/panel.html",
+        "ui://Beta/3.1.0/panel.html",
+    ]
+
+
+def test_each_pointer_names_the_uri_its_document_registered_under(build_package):
+    """The pointer and the registration are two derivations that must not drift."""
+    build_package("arcade_alpha", version="2.0.0", tool_name="ShowPanelAlpha")
+    build_package("arcade_beta", version="3.1.0", tool_name="ShowPanelBeta")
+
+    catalog = ToolCatalog()
+    _compose(catalog, "arcade_alpha", "arcade_beta")
+
+    for materialized in catalog:
+        pointed = _pointed(materialized.definition)
+        assert pointed in catalog.resources
+        assert catalog.resources.get(pointed).resource.uri == pointed
+
+
+def test_the_document_carries_the_shipping_toolkit_not_the_server(build_package):
+    build_package("arcade_alpha", version="2.0.0")
+
+    catalog = ToolCatalog()
+    _compose(catalog, "arcade_alpha")
+
+    definition = next(iter(catalog)).definition
+    assert definition.toolkit.name == "Combined"
+    assert _pointed(definition) == "ui://Alpha/2.0.0/panel.html"
+
+
+def test_two_declarations_at_one_path_in_one_package_still_collide(build_package):
+    root = build_package("arcade_alpha", version="2.0.0", ui_source=TWO_AT_ONE_PATH)
+    (root / "arcade_alpha" / "tools.py").unlink()
+    toolkit = Toolkit.from_directory(root)
+    (root / "arcade_alpha" / "tools.py").write_text(
+        textwrap.dedent(TOOLS_MODULE).format(package="arcade_alpha", tool_name="ShowPanel"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ToolkitLoadError) as raised:
+        ToolCatalog().add_toolkit(toolkit)
+
+    message = str(raised.value)
+    assert "arcade_alpha.ui.first" in message
+    assert "arcade_alpha.ui.second" in message
+
+
+def test_a_package_that_is_not_installed_falls_back_to_the_server(build_package):
+    build_package("loose_alpha")
+
+    catalog = ToolCatalog()
+    _compose(catalog, "loose_alpha")
+
+    definition = next(iter(catalog)).definition
+    assert _pointed(definition) == "ui://Combined/1.0.0/panel.html"
+
+
+def test_the_toolkit_path_is_unchanged(build_package):
+    """An installed toolkit ships its own documents, so its URIs do not move."""
+    root = build_package("arcade_alpha", version="2.0.0")
+    toolkit = Toolkit.from_directory(root)
+
+    catalog = ToolCatalog()
+    catalog.add_toolkit(toolkit)
+
+    definition = next(iter(catalog)).definition
+    assert definition.toolkit.name == "Alpha"
+    assert _pointed(definition) == "ui://Alpha/2.0.0/panel.html"
+    assert "ui://Alpha/2.0.0/panel.html" in catalog.resources

--- a/libs/tests/core/test_resource_file_declaration.py
+++ b/libs/tests/core/test_resource_file_declaration.py
@@ -1,0 +1,131 @@
+"""A resource can name a file beside its module instead of reading it by hand.
+
+The file is resolved against the declaring module and read once at
+registration, as text for a text media type and as bytes otherwise, and the
+resource takes the file's name as its path unless one is given.
+"""
+
+import sys
+import textwrap
+
+import pytest
+from arcade_core.catalog import ToolCatalog
+from arcade_core.errors import ToolkitLoadError
+from arcade_core.resource_schema import BlobResourceContents, TextResourceContents
+from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, resource
+from arcade_core.toolkit import Toolkit
+
+TOOLS_MODULE = '''
+from typing import Annotated
+
+from arcade_tdk import tool
+
+
+@tool
+def add_numbers(
+    a: Annotated[int, "The first number"],
+    b: Annotated[int, "The second number"],
+) -> Annotated[int, "The sum"]:
+    """Add two numbers."""
+    return a + b
+'''
+
+UI_MODULE = """
+from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, resource
+
+
+@resource(file="dashboard.html", mime_type=UI_DOCUMENT_MIME_TYPE)
+def dashboard() -> None: ...
+
+
+@resource(file="icon.png", mime_type="image/png")
+def icon() -> None: ...
+
+
+@resource(path="nested/dash.html", file="dashboard.html", mime_type="text/html")
+def nested() -> None: ...
+"""
+
+MISSING_MODULE = """
+from arcade_core.resources import resource
+
+
+@resource(file="missing.html", mime_type="text/html")
+def missing() -> None: ...
+"""
+
+
+def _forget(package_name):
+    for name in [n for n in sys.modules if n == package_name or n.startswith(package_name + ".")]:
+        del sys.modules[name]
+
+
+@pytest.fixture
+def build_toolkit(tmp_path, monkeypatch):
+    built = []
+
+    def build(name, ui_source, files):
+        root = tmp_path / name
+        package = root / name
+        package.mkdir(parents=True)
+        (root / "pyproject.toml").write_text(
+            f'[project]\nname = "{name}"\nversion = "1.0.0"\n', encoding="utf-8"
+        )
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "tools.py").write_text(textwrap.dedent(TOOLS_MODULE), encoding="utf-8")
+        (package / "ui.py").write_text(textwrap.dedent(ui_source), encoding="utf-8")
+        for filename, body in files.items():
+            mode = "wb" if isinstance(body, bytes) else "w"
+            with open(package / filename, mode) as handle:
+                handle.write(body)
+        monkeypatch.syspath_prepend(str(root))
+        _forget(name)
+        built.append(name)
+        return Toolkit.from_directory(root)
+
+    yield build
+    for name in built:
+        _forget(name)
+
+
+FILES = {"dashboard.html": "<!DOCTYPE html><p>hi</p>", "icon.png": b"\x89PNG\r\n"}
+
+
+def test_a_text_file_is_served_as_text_under_its_own_name(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit("arcade_widgets", UI_MODULE, FILES))
+
+    registered = catalog.resources.get("ui://Widgets/1.0.0/dashboard.html")
+
+    assert isinstance(registered.contents, TextResourceContents)
+    assert registered.contents.text == "<!DOCTYPE html><p>hi</p>"
+    assert registered.contents.mimeType == UI_DOCUMENT_MIME_TYPE
+
+
+def test_a_binary_file_is_served_as_a_blob(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit("arcade_widgets", UI_MODULE, FILES))
+
+    registered = catalog.resources.get("ui://Widgets/1.0.0/icon.png")
+
+    assert isinstance(registered.contents, BlobResourceContents)
+    assert registered.contents.blob == "iVBORw0K"
+
+
+def test_a_given_path_wins_over_the_file_name(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit("arcade_widgets", UI_MODULE, FILES))
+
+    assert "ui://Widgets/1.0.0/nested/dash.html" in catalog.resources
+
+
+def test_a_missing_file_fails_the_toolkit(build_toolkit):
+    toolkit = build_toolkit("arcade_widgets", MISSING_MODULE, {})
+
+    with pytest.raises(ToolkitLoadError, match="missing.html"):
+        ToolCatalog().add_toolkit(toolkit)
+
+
+def test_a_declaration_needs_a_path_or_a_file():
+    with pytest.raises(TypeError, match="path or a file"):
+        resource()

--- a/libs/tests/core/test_resource_uri_qualification.py
+++ b/libs/tests/core/test_resource_uri_qualification.py
@@ -183,11 +183,10 @@ def test_declaring_through_the_registry_qualifies_the_uri():
         path="draft-review.html",
         name="Draft review",
         mime_type="text/html;profile=example",
+        func=lambda: "<!DOCTYPE html>",
     )
 
-    registered = registry.declare(
-        declaration, "<!DOCTYPE html>", toolkit_name="Gmail", toolkit_version="8.1.0"
-    )
+    registered = registry.declare(declaration, toolkit_name="Gmail", toolkit_version="8.1.0")
 
     assert registered.resource.uri == "ui://Gmail/8.1.0/draft-review.html"
     assert registry.get("ui://Gmail/8.1.0/draft-review.html").contents.text == "<!DOCTYPE html>"
@@ -197,8 +196,7 @@ def test_the_contents_uri_matches_the_qualified_listing_uri():
     """A read that echoes a different URI than the listing breaks host-side caching."""
     registry = ResourceRegistry()
     registered = registry.declare(
-        ResourceDeclaration(path="a.html", name="a"),
-        "x",
+        ResourceDeclaration(path="a.html", name="a", func=lambda: "x"),
         toolkit_name="Gmail",
         toolkit_version="8.1.0",
     )

--- a/libs/tests/core/test_tool_definition_meta.py
+++ b/libs/tests/core/test_tool_definition_meta.py
@@ -1,0 +1,64 @@
+"""A tool definition's ``_meta`` must serialize exactly as it goes on the wire.
+
+The alias is the wire contract: a caller decodes ``_meta``, so a value emitted
+under the Python name, or dropped between a dump and a validate, is a break.
+"""
+
+from arcade_core.schema import (
+    ToolDefinition,
+    ToolInput,
+    ToolkitDefinition,
+    ToolOutput,
+    ToolRequirements,
+)
+
+POINTER = {"ui": {"resourceUri": "ui://Math/0.1.0/sum-list.html"}}
+
+
+def _definition(**overrides) -> ToolDefinition:
+    fields = {
+        "name": "SumList",
+        "fully_qualified_name": "Math.SumList",
+        "description": "Sum a list of numbers",
+        "toolkit": ToolkitDefinition(name="Math", version="0.1.0"),
+        "input": ToolInput(parameters=[]),
+        "output": ToolOutput(),
+        "requirements": ToolRequirements(),
+    }
+    fields.update(overrides)
+    return ToolDefinition(**fields)
+
+
+def test_meta_serializes_under_the_underscore_key():
+    dumped = _definition(meta=POINTER).model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["_meta"] == POINTER
+    assert "meta" not in dumped
+
+
+def test_meta_is_read_from_the_underscore_key():
+    definition = ToolDefinition.model_validate({
+        **_definition().model_dump(exclude_none=True),
+        "_meta": POINTER,
+    })
+
+    assert definition.meta == POINTER
+
+
+def test_meta_survives_a_dump_and_validate_round_trip():
+    """``model_dump()`` emits the Python name, so validation has to accept it too."""
+    definition = _definition(meta=POINTER)
+
+    round_tripped = ToolDefinition.model_validate(definition.model_dump())
+
+    assert round_tripped.meta == POINTER
+
+
+def test_meta_is_absent_until_something_sets_it():
+    definition = _definition()
+
+    dumped = definition.model_dump(by_alias=True, exclude_none=True)
+
+    assert definition.meta is None
+    assert "_meta" not in dumped
+    assert "meta" not in dumped

--- a/libs/tests/core/test_tool_ui_declaration.py
+++ b/libs/tests/core/test_tool_ui_declaration.py
@@ -1,8 +1,8 @@
-"""A tool names its user interface by path, and the catalog derives the URI.
+"""A tool passes the declaration of its user interface, and the catalog does the rest.
 
-The tool and the resource it names are qualified by one derivation, so the two
-agree without the author ever writing a URI. A tool naming a path nothing in its
-toolkit declares fails the load, as every other authoring mistake does.
+The tool and its interface are qualified by one derivation, so they agree without
+the author ever writing a URI. Registering the tool registers the interface, so a
+tool can only point at something the catalog serves.
 """
 
 import sys
@@ -11,23 +11,48 @@ import textwrap
 import pytest
 from arcade_core.catalog import ToolCatalog
 from arcade_core.errors import ToolDefinitionError, ToolkitLoadError
-from arcade_core.resources import ui_pointer, ui_resource_uri
+from arcade_core.resources import UI_DOCUMENT_MIME_TYPE, resource, ui_pointer
 from arcade_core.toolkit import Toolkit
 from arcade_tdk import tool
+
+UI_MODULE = '''
+from arcade_core.resources import resource
+
+
+@resource(file="dashboard.html")
+def dashboard() -> None:
+    """The numbers and their sum."""
+
+
+@resource(path="report.html", mime_type="text/html")
+def report() -> str:
+    return "<!DOCTYPE html><p>report</p>"
+'''
 
 TOOLS_MODULE = '''
 from typing import Annotated
 
 from arcade_tdk import tool
 
+from arcade_widgets.ui import dashboard
 
-@tool(ui="dashboard.html")
+
+@tool(ui=dashboard)
 def add_numbers(
     a: Annotated[int, "The first number"],
     b: Annotated[int, "The second number"],
 ) -> Annotated[int, "The sum"]:
     """Add two numbers."""
     return a + b
+
+
+@tool(ui=dashboard)
+def multiply_numbers(
+    a: Annotated[int, "The first number"],
+    b: Annotated[int, "The second number"],
+) -> Annotated[int, "The product"]:
+    """Multiply two numbers."""
+    return a * b
 
 
 @tool
@@ -39,29 +64,25 @@ def subtract_numbers(
     return a - b
 '''
 
-UI_MODULE = """
+WRONG_TYPE_UI_MODULE = '''
 from arcade_core.resources import resource
 
 
-@resource(path="dashboard.html", mime_type="text/html;profile=example")
-def dashboard() -> str:
-    return "<!DOCTYPE html><p>hi</p>"
+@resource(file="dashboard.html", mime_type="text/html")
+def dashboard() -> None:
+    """Declared as plain HTML, which a host will not render as an interface."""
+'''
+
+SECOND_UI_MODULE = """
+from arcade_core.resources import resource
+
+
+@resource(path="dashboard.html", mime_type="text/html")
+def other_dashboard() -> str:
+    return "<!DOCTYPE html><p>other</p>"
 """
 
-DANGLING_TOOLS_MODULE = '''
-from typing import Annotated
-
-from arcade_tdk import tool
-
-
-@tool(ui="missing.html")
-def add_numbers(
-    a: Annotated[int, "The first number"],
-    b: Annotated[int, "The second number"],
-) -> Annotated[int, "The sum"]:
-    """Add two numbers."""
-    return a + b
-'''
+DASHBOARD_HTML = "<!DOCTYPE html><p>hi</p>"
 
 
 def _forget(package_name):
@@ -72,9 +93,9 @@ def _forget(package_name):
 @pytest.fixture
 def build_toolkit(tmp_path, monkeypatch):
     """Write a toolkit to disk and load it the way installed-toolkit discovery does."""
-    built = []
+    name = "arcade_widgets"
 
-    def build(name, version, tools_source, ui_source=None):
+    def build(version="2.3.1", tools_source=TOOLS_MODULE, ui_source=UI_MODULE, extra=None):
         root = tmp_path / name
         package = root / name
         package.mkdir(parents=True)
@@ -82,86 +103,133 @@ def build_toolkit(tmp_path, monkeypatch):
             f'[project]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8"
         )
         (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "ui.py").write_text(textwrap.dedent(ui_source), encoding="utf-8")
+        (package / "dashboard.html").write_text(DASHBOARD_HTML, encoding="utf-8")
         (package / "tools.py").write_text(textwrap.dedent(tools_source), encoding="utf-8")
-        if ui_source is not None:
-            (package / "ui.py").write_text(textwrap.dedent(ui_source), encoding="utf-8")
+        for filename, source in (extra or {}).items():
+            (package / filename).write_text(textwrap.dedent(source), encoding="utf-8")
         monkeypatch.syspath_prepend(str(root))
         _forget(name)
-        built.append(name)
         return Toolkit.from_directory(root)
 
     yield build
-    for name in built:
-        _forget(name)
+    _forget(name)
 
 
 def _by_name(catalog):
     return {materialized.definition.name: materialized.definition for materialized in catalog}
 
 
-def test_the_tool_and_its_resource_derive_the_same_uri(build_toolkit):
-    catalog = ToolCatalog()
-    catalog.add_toolkit(build_toolkit("arcade_widgets", "2.3.1", TOOLS_MODULE, UI_MODULE))
-
-    add = _by_name(catalog)["AddNumbers"]
+def _uri(definition, path):
     # Built from the tool's own toolkit fields rather than written out, so the
     # two derivations cannot drift apart without this failing.
-    expected = f"ui://{add.toolkit.name}/{add.toolkit.version}/dashboard.html"
+    return f"ui://{definition.toolkit.name}/{definition.toolkit.version}/{path}"
 
-    assert ui_resource_uri(add.meta) == expected
-    assert catalog.resources.get(expected).resource.uri == expected
+
+def test_the_tool_and_its_interface_share_one_uri(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit())
+
+    add = _by_name(catalog)["AddNumbers"]
+    uri = _uri(add, "dashboard.html")
+
+    assert add.meta == ui_pointer(uri)
+    assert catalog.resources.get(uri).contents.text == DASHBOARD_HTML
+
+
+def test_an_interface_needs_no_media_type_from_its_author(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit())
+
+    add = _by_name(catalog)["AddNumbers"]
+    registered = catalog.resources.get(_uri(add, "dashboard.html")).resource
+
+    assert registered.mimeType == UI_DOCUMENT_MIME_TYPE
+    assert registered.description == "The numbers and their sum."
+
+
+def test_two_tools_sharing_an_interface_register_it_once(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit())
+
+    definitions = _by_name(catalog)
+
+    assert definitions["AddNumbers"].meta == definitions["MultiplyNumbers"].meta
+    assert [registered.resource.name for registered in catalog.resources] == ["dashboard", "report"]
 
 
 def test_a_tool_that_names_no_interface_carries_no_pointer(build_toolkit):
     catalog = ToolCatalog()
-    catalog.add_toolkit(build_toolkit("arcade_widgets", "2.3.1", TOOLS_MODULE, UI_MODULE))
+    catalog.add_toolkit(build_toolkit())
 
     assert _by_name(catalog)["SubtractNumbers"].meta is None
 
 
 def test_the_pointer_serializes_under_the_underscore_key(build_toolkit):
     catalog = ToolCatalog()
-    catalog.add_toolkit(build_toolkit("arcade_widgets", "2.3.1", TOOLS_MODULE, UI_MODULE))
+    catalog.add_toolkit(build_toolkit())
 
     add = _by_name(catalog)["AddNumbers"]
     dumped = add.model_dump(by_alias=True, exclude_none=True)
 
-    assert dumped["_meta"] == ui_pointer(ui_resource_uri(add.meta))
+    assert dumped["_meta"] == {"ui": {"resourceUri": _uri(add, "dashboard.html")}}
     assert "meta" not in dumped
 
 
-def test_a_path_no_resource_declares_fails_the_toolkit(build_toolkit):
-    toolkit = build_toolkit("arcade_widgets", "2.3.1", DANGLING_TOOLS_MODULE, UI_MODULE)
+def test_an_interface_declared_with_another_media_type_fails_the_load(build_toolkit):
+    toolkit = build_toolkit(ui_source=WRONG_TYPE_UI_MODULE)
 
-    with pytest.raises(ToolkitLoadError, match=r"AddNumbers.*missing\.html") as raised:
+    with pytest.raises(ToolDefinitionError, match="text/html;profile=mcp-app"):
         ToolCatalog().add_toolkit(toolkit)
 
-    assert "@resource" in str(raised.value)
 
+def test_a_second_declaration_of_the_same_path_fails_the_load(build_toolkit):
+    toolkit = build_toolkit(extra={"more_ui.py": SECOND_UI_MODULE})
 
-def test_a_toolkit_with_no_resources_fails_the_same_way(build_toolkit):
-    toolkit = build_toolkit("arcade_widgets", "2.3.1", DANGLING_TOOLS_MODULE)
-
-    with pytest.raises(ToolkitLoadError, match=r"missing\.html"):
+    with pytest.raises(ToolkitLoadError, match="both declare"):
         ToolCatalog().add_toolkit(toolkit)
+
+
+def test_registering_a_tool_alone_registers_its_interface():
+    @resource(path="dashboard.html")
+    def dashboard() -> str:
+        return DASHBOARD_HTML
+
+    @tool(ui=dashboard)
+    def show() -> str:
+        """Show a dashboard."""
+        return ""
+
+    catalog = ToolCatalog()
+    catalog.add_tool(show, "widgets", toolkit_version="1.0.0")
+
+    registered = catalog.resources.get("ui://Widgets/1.0.0/dashboard.html")
+
+    assert registered.resource.mimeType == UI_DOCUMENT_MIME_TYPE
+    assert registered.contents.text == DASHBOARD_HTML
 
 
 def test_the_uri_is_qualified_by_the_normalized_toolkit_name_and_version():
-    @tool(ui="ui/dashboard.html")
+    @resource(path="ui/dashboard.html")
+    def dashboard() -> str:
+        return DASHBOARD_HTML
+
+    @tool(ui=dashboard)
     def show() -> str:
         """Show a dashboard."""
         return ""
 
     definition = ToolCatalog.create_tool_definition(show, "arcade_google_docs", "8.1.0")
 
-    assert (
-        ui_resource_uri(definition.meta)
-        == f"ui://{definition.toolkit.name}/8.1.0/ui/dashboard.html"
-    )
+    assert definition.meta == ui_pointer(f"ui://{definition.toolkit.name}/8.1.0/ui/dashboard.html")
 
 
 def test_a_toolkit_without_a_version_cannot_name_an_interface():
-    @tool(ui="dashboard.html")
+    @resource(path="dashboard.html")
+    def dashboard() -> str:
+        return DASHBOARD_HTML
+
+    @tool(ui=dashboard)
     def show() -> str:
         """Show a dashboard."""
         return ""
@@ -171,18 +239,14 @@ def test_a_toolkit_without_a_version_cannot_name_an_interface():
 
 
 def test_a_traversing_path_is_refused_when_the_tool_is_defined():
-    @tool(ui="../secret.html")
+    @resource(path="../secret.html")
+    def secret() -> str:
+        return ""
+
+    @tool(ui=secret)
     def show() -> str:
         """Show a dashboard."""
         return ""
 
     with pytest.raises(ToolDefinitionError, match="traverse"):
         ToolCatalog.create_tool_definition(show, "widgets", "1.0.0")
-
-
-def test_ui_resource_uri_reads_only_a_well_formed_pointer():
-    assert ui_resource_uri(None) is None
-    assert ui_resource_uri({}) is None
-    assert ui_resource_uri({"ui": "not an object"}) is None
-    assert ui_resource_uri({"ui": {"resourceUri": 7}}) is None
-    assert ui_resource_uri(ui_pointer("ui://Kit/1.0.0/a.html")) == "ui://Kit/1.0.0/a.html"

--- a/libs/tests/core/test_tool_ui_declaration.py
+++ b/libs/tests/core/test_tool_ui_declaration.py
@@ -82,6 +82,20 @@ def other_dashboard() -> str:
     return "<!DOCTYPE html><p>other</p>"
 """
 
+TWIN_UI_MODULE = """
+from arcade_core.resources import resource
+
+
+@resource(path="dashboard.html", name="dashboard", mime_type="text/html")
+def first() -> str:
+    return "<!DOCTYPE html><p>first</p>"
+
+
+@resource(path="dashboard.html", name="dashboard", mime_type="text/html")
+def second() -> str:
+    return "<!DOCTYPE html><p>second</p>"
+"""
+
 DASHBOARD_HTML = "<!DOCTYPE html><p>hi</p>"
 
 
@@ -185,6 +199,14 @@ def test_an_interface_declared_with_another_media_type_fails_the_load(build_tool
 
 def test_a_second_declaration_of_the_same_path_fails_the_load(build_toolkit):
     toolkit = build_toolkit(extra={"more_ui.py": SECOND_UI_MODULE})
+
+    with pytest.raises(ToolkitLoadError, match="both declare"):
+        ToolCatalog().add_toolkit(toolkit)
+
+
+def test_two_declarations_that_read_alike_are_still_two(build_toolkit):
+    """Only the declaration object itself counts as already registered, never a lookalike."""
+    toolkit = build_toolkit(extra={"twins.py": TWIN_UI_MODULE})
 
     with pytest.raises(ToolkitLoadError, match="both declare"):
         ToolCatalog().add_toolkit(toolkit)

--- a/libs/tests/core/test_tool_ui_declaration.py
+++ b/libs/tests/core/test_tool_ui_declaration.py
@@ -1,0 +1,188 @@
+"""A tool names its user interface by path, and the catalog derives the URI.
+
+The tool and the resource it names are qualified by one derivation, so the two
+agree without the author ever writing a URI. A tool naming a path nothing in its
+toolkit declares fails the load, as every other authoring mistake does.
+"""
+
+import sys
+import textwrap
+
+import pytest
+from arcade_core.catalog import ToolCatalog
+from arcade_core.errors import ToolDefinitionError, ToolkitLoadError
+from arcade_core.resources import ui_pointer, ui_resource_uri
+from arcade_core.toolkit import Toolkit
+from arcade_tdk import tool
+
+TOOLS_MODULE = '''
+from typing import Annotated
+
+from arcade_tdk import tool
+
+
+@tool(ui="dashboard.html")
+def add_numbers(
+    a: Annotated[int, "The first number"],
+    b: Annotated[int, "The second number"],
+) -> Annotated[int, "The sum"]:
+    """Add two numbers."""
+    return a + b
+
+
+@tool
+def subtract_numbers(
+    a: Annotated[int, "The first number"],
+    b: Annotated[int, "The second number"],
+) -> Annotated[int, "The difference"]:
+    """Subtract two numbers."""
+    return a - b
+'''
+
+UI_MODULE = """
+from arcade_core.resources import resource
+
+
+@resource(path="dashboard.html", mime_type="text/html;profile=example")
+def dashboard() -> str:
+    return "<!DOCTYPE html><p>hi</p>"
+"""
+
+DANGLING_TOOLS_MODULE = '''
+from typing import Annotated
+
+from arcade_tdk import tool
+
+
+@tool(ui="missing.html")
+def add_numbers(
+    a: Annotated[int, "The first number"],
+    b: Annotated[int, "The second number"],
+) -> Annotated[int, "The sum"]:
+    """Add two numbers."""
+    return a + b
+'''
+
+
+def _forget(package_name):
+    for name in [n for n in sys.modules if n == package_name or n.startswith(package_name + ".")]:
+        del sys.modules[name]
+
+
+@pytest.fixture
+def build_toolkit(tmp_path, monkeypatch):
+    """Write a toolkit to disk and load it the way installed-toolkit discovery does."""
+    built = []
+
+    def build(name, version, tools_source, ui_source=None):
+        root = tmp_path / name
+        package = root / name
+        package.mkdir(parents=True)
+        (root / "pyproject.toml").write_text(
+            f'[project]\nname = "{name}"\nversion = "{version}"\n', encoding="utf-8"
+        )
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "tools.py").write_text(textwrap.dedent(tools_source), encoding="utf-8")
+        if ui_source is not None:
+            (package / "ui.py").write_text(textwrap.dedent(ui_source), encoding="utf-8")
+        monkeypatch.syspath_prepend(str(root))
+        _forget(name)
+        built.append(name)
+        return Toolkit.from_directory(root)
+
+    yield build
+    for name in built:
+        _forget(name)
+
+
+def _by_name(catalog):
+    return {materialized.definition.name: materialized.definition for materialized in catalog}
+
+
+def test_the_tool_and_its_resource_derive_the_same_uri(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit("arcade_widgets", "2.3.1", TOOLS_MODULE, UI_MODULE))
+
+    add = _by_name(catalog)["AddNumbers"]
+    # Built from the tool's own toolkit fields rather than written out, so the
+    # two derivations cannot drift apart without this failing.
+    expected = f"ui://{add.toolkit.name}/{add.toolkit.version}/dashboard.html"
+
+    assert ui_resource_uri(add.meta) == expected
+    assert catalog.resources.get(expected).resource.uri == expected
+
+
+def test_a_tool_that_names_no_interface_carries_no_pointer(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit("arcade_widgets", "2.3.1", TOOLS_MODULE, UI_MODULE))
+
+    assert _by_name(catalog)["SubtractNumbers"].meta is None
+
+
+def test_the_pointer_serializes_under_the_underscore_key(build_toolkit):
+    catalog = ToolCatalog()
+    catalog.add_toolkit(build_toolkit("arcade_widgets", "2.3.1", TOOLS_MODULE, UI_MODULE))
+
+    add = _by_name(catalog)["AddNumbers"]
+    dumped = add.model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["_meta"] == ui_pointer(ui_resource_uri(add.meta))
+    assert "meta" not in dumped
+
+
+def test_a_path_no_resource_declares_fails_the_toolkit(build_toolkit):
+    toolkit = build_toolkit("arcade_widgets", "2.3.1", DANGLING_TOOLS_MODULE, UI_MODULE)
+
+    with pytest.raises(ToolkitLoadError, match=r"AddNumbers.*missing\.html") as raised:
+        ToolCatalog().add_toolkit(toolkit)
+
+    assert "@resource" in str(raised.value)
+
+
+def test_a_toolkit_with_no_resources_fails_the_same_way(build_toolkit):
+    toolkit = build_toolkit("arcade_widgets", "2.3.1", DANGLING_TOOLS_MODULE)
+
+    with pytest.raises(ToolkitLoadError, match=r"missing\.html"):
+        ToolCatalog().add_toolkit(toolkit)
+
+
+def test_the_uri_is_qualified_by_the_normalized_toolkit_name_and_version():
+    @tool(ui="ui/dashboard.html")
+    def show() -> str:
+        """Show a dashboard."""
+        return ""
+
+    definition = ToolCatalog.create_tool_definition(show, "arcade_google_docs", "8.1.0")
+
+    assert (
+        ui_resource_uri(definition.meta)
+        == f"ui://{definition.toolkit.name}/8.1.0/ui/dashboard.html"
+    )
+
+
+def test_a_toolkit_without_a_version_cannot_name_an_interface():
+    @tool(ui="dashboard.html")
+    def show() -> str:
+        """Show a dashboard."""
+        return ""
+
+    with pytest.raises(ToolDefinitionError, match="version"):
+        ToolCatalog.create_tool_definition(show, "widgets")
+
+
+def test_a_traversing_path_is_refused_when_the_tool_is_defined():
+    @tool(ui="../secret.html")
+    def show() -> str:
+        """Show a dashboard."""
+        return ""
+
+    with pytest.raises(ToolDefinitionError, match="traverse"):
+        ToolCatalog.create_tool_definition(show, "widgets", "1.0.0")
+
+
+def test_ui_resource_uri_reads_only_a_well_formed_pointer():
+    assert ui_resource_uri(None) is None
+    assert ui_resource_uri({}) is None
+    assert ui_resource_uri({"ui": "not an object"}) is None
+    assert ui_resource_uri({"ui": {"resourceUri": 7}}) is None
+    assert ui_resource_uri(ui_pointer("ui://Kit/1.0.0/a.html")) == "ui://Kit/1.0.0/a.html"

--- a/libs/tests/core/test_toolkit_resource_authoring.py
+++ b/libs/tests/core/test_toolkit_resource_authoring.py
@@ -13,7 +13,7 @@ import textwrap
 import pytest
 from arcade_core.catalog import ToolCatalog
 from arcade_core.errors import ToolkitLoadError
-from arcade_core.resources import RESOURCE_ATTRIBUTE, ResourceDeclaration, resource
+from arcade_core.resources import ResourceDeclaration, resource
 from arcade_core.toolkit import Toolkit
 
 TOOL_MODULE = '''
@@ -342,7 +342,7 @@ def test_the_decorator_leaves_the_function_callable():
         return "hello"
 
     assert body() == "hello"
-    assert isinstance(getattr(body, RESOURCE_ATTRIBUTE), ResourceDeclaration)
+    assert isinstance(body, ResourceDeclaration)
 
 
 def test_the_declaration_name_defaults_to_the_function_name():
@@ -350,7 +350,7 @@ def test_the_declaration_name_defaults_to_the_function_name():
     def draft_review() -> str:
         return "x"
 
-    assert getattr(draft_review, RESOURCE_ATTRIBUTE).name == "draft_review"
+    assert draft_review.name == "draft_review"
 
 
 def test_the_decorator_refuses_an_async_function():
@@ -381,7 +381,7 @@ def test_a_lookalike_decorator_is_never_recorded_by_discovery(widgets_package):
 
 
 def test_a_declaration_lost_to_a_wrapper_is_reported(widgets_package):
-    """The scan knows this one is ours, so a missing marker is diagnosable."""
+    """The scan knows this one is ours, so a replaced declaration is diagnosable."""
     (widgets_package / "arcade_widgets" / "wrapped.py").write_text(
         textwrap.dedent(WRAPPED_MODULE), encoding="utf-8"
     )
@@ -391,8 +391,8 @@ def test_a_declaration_lost_to_a_wrapper_is_reported(widgets_package):
     with pytest.raises(ToolkitLoadError) as exc_info:
         catalog.add_toolkit(toolkit)
 
-    assert "functools.wraps" in str(exc_info.value)
-    assert "wrapped" in str(exc_info.value)
+    assert "declaration" in str(exc_info.value)
+    assert "arcade_widgets.wrapped" in str(exc_info.value)
 
 
 def test_a_resource_returning_a_coroutine_is_reported(widgets_package):

--- a/libs/tests/sdk/test_tool_decorator.py
+++ b/libs/tests/sdk/test_tool_decorator.py
@@ -3,6 +3,7 @@ import inspect
 
 import pytest
 from arcade_core.auth import AuthProviderType, Google, Microsoft, MicrosoftPowerBI
+from arcade_core.resources import resource
 from arcade_tdk import tool
 from arcade_tdk.auth import OAuth2, PagerDuty
 
@@ -281,12 +282,25 @@ class TestArcadeTdkToolHasNoMCPSpecificKwargs:
 
 
 def test_ui_is_recorded_on_the_function():
-    @tool(ui="dashboard.html")
+    @resource(path="dashboard.html")
+    def dashboard() -> str:
+        return ""
+
+    @tool(ui=dashboard)
     def with_ui() -> str:
         """A tool with an interface."""
         return ""
 
-    assert with_ui.__tool_ui__ == "dashboard.html"
+    assert with_ui.__tool_ui__ is dashboard
+
+
+def test_ui_refuses_anything_but_a_declaration():
+    with pytest.raises(TypeError, match="@resource"):
+
+        @tool(ui="dashboard.html")
+        def with_path() -> str:
+            """A tool with a path where its interface should be."""
+            return ""
 
 
 def test_ui_defaults_to_none():

--- a/libs/tests/sdk/test_tool_decorator.py
+++ b/libs/tests/sdk/test_tool_decorator.py
@@ -278,3 +278,21 @@ class TestArcadeTdkToolHasNoMCPSpecificKwargs:
         assert "mcp" not in doc
         assert "tasksupport" not in doc
         assert "arcade_mcp_server" not in doc
+
+
+def test_ui_is_recorded_on_the_function():
+    @tool(ui="dashboard.html")
+    def with_ui() -> str:
+        """A tool with an interface."""
+        return ""
+
+    assert with_ui.__tool_ui__ == "dashboard.html"
+
+
+def test_ui_defaults_to_none():
+    @tool
+    def without_ui() -> str:
+        """A tool with no interface."""
+        return ""
+
+    assert without_ui.__tool_ui__ is None


### PR DESCRIPTION
Resolves [TOO-1941](https://linear.app/arcadedev/issue/TOO-1941).
Resolves [TOO-1942](https://linear.app/arcadedev/issue/TOO-1942).

## Before

As a tooling author, I want a tool in my toolkit to come with a user interface that a client can render when the tool is called. I have written the interface as an HTML document and declared it in my toolkit with `@resource`, so the worker serves it under a URI qualified by my toolkit's name and version. When I look for a way to say which tool the document belongs to, `@tool` has nothing for it, the tool definition has no field that could carry it, and the only place such a pointer can be written is on the server object my toolkit's entrypoint builds, which installed-toolkit discovery never imports. I can start my toolkit locally and point a client that renders tool interfaces at it, and nothing renders: the tool listing carries no pointer, the server's own endpoint knows nothing about the document, and if the client runs in a browser it cannot even read the server's responses, because the server names an allowed origin only on the preflight.

## After

As a tooling author, I want the same tool to come with the same interface. I declare the document with `@resource(file="sum-list.html")` on a stub function beside the file, and the decorator hands me back the declaration. In the tool's module I import that declaration and write `ui=sum_list_ui` on the tool. When the tool is registered, its definition carries the document's full URI under `_meta`, and the document is registered with it under that same URI, because one derivation qualifies both. I never write a URI or a media type: a document a tool names is served as `text/html;profile=mcp-app`, and if I had declared it as something else the toolkit fails to load with an error saying a client will not render it. If I pass anything but a declaration as `ui`, the module fails to import. I can start my toolkit locally and point the same client at it, and the interface renders: the tool listing carries the pointer, the server's own endpoint lists and reads the document, and a client running in a browser from an allowed origin reads every response, because the origin is echoed on all of them rather than on the preflight alone.

## Why `@resource` returns the declaration rather than the function

A tool has to name its interface without a string that must match something declared elsewhere. Returning the declaration makes the module attribute the thing a tool imports and passes, keeps it callable so a toolkit's tests can still run a body that produces contents, and leaves `ui` with one accepted type. arcade-core 4.16.0 returned the bare function; nothing consumes that yet.

## Why every tool definition now serializes `_meta`

The catalog endpoint serializes a definition with every field present, so a tool that names no interface emits `"_meta": null`, exactly as `deprecation_message` and `metadata` do today for tools that set neither. A consumer decoding into an optional field reads null as absent, and the engine's decoder is tested to do so.

Releases arcade-core 4.17.0, arcade-tdk 3.12.0 and arcade-mcp-server 1.29.0.

~ 🐙 Eriq, Eric's Agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches catalog registration, resource URI identity, and tool listing serialization; mis-qualification or duplicate paths fail load, but behavior is largely additive behind new `ui=` usage.
> 
> **Overview**
> **Tools can declare a renderable UI** by passing the `ResourceDeclaration` returned from `@resource` into `@tool(ui=...)`. Registration registers that document once (shared across tools), forces the MCP-app HTML media type for interfaces, and puts `ui.resourceUri` on the tool definition as `_meta`.
> 
> **`@resource` is reworked**: it now returns a `ResourceDeclaration` (callable for tests) instead of tagging the function with `__arcade_resource__`. Declarations can use `file=` beside the module; `ResourceRegistry.declare` resolves file/function bodies internally. **UI URIs qualify by the installed package that ships the declaration** (`interface_uri`), not the composing server, so multi-toolkit MCP apps avoid path collisions.
> 
> **Wire/API plumbing**: `ToolDefinition` gains optional `_meta` (serialized with `populate_by_name`). MCP conversion merges existing `_meta` with `arcade` metadata; the MCP server loads catalog resources at startup and echoes **CORS allow-origin on every HTTP response**, not only OPTIONS.
> 
> Bumps **arcade-core 4.17.0**, **arcade-tdk 3.12.0**, **arcade-mcp-server 1.29.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1a763ac871d97a022a4f7308166280e83dc7a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

