### PR TITLE
feat(core): let a resource declare its own _meta [TOO-1943, TOO-1944]

### DIFF
--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -165,6 +165,10 @@ class ResourceDeclaration:
     file: Path | None = None
     #: Produces the contents when no file is declared. Called once, at registration.
     func: Callable[[], Any] | None = field(default=None, compare=False, repr=False)
+    #: Out-of-band data for the resource, carried through untouched. A host reads a
+    #: document's rendering contract from the read response, so registration puts
+    #: this on the contents as well as on the listing entry.
+    meta: dict[str, Any] | None = None
 
     def __call__(self) -> Any:
         """Run the declaring function, so a toolkit's own tests can call it directly."""
@@ -277,6 +281,7 @@ def resource(
     title: str | None = None,
     description: str | None = None,
     mime_type: str | None = None,
+    meta: dict[str, Any] | None = None,
     scheme: str = UI_SCHEME,
 ) -> Callable[[Callable[..., Any]], ResourceDeclaration]:
     """Declare a static resource a toolkit ships.
@@ -300,6 +305,12 @@ def resource(
         @resource(path="draft-review.html", mime_type="text/html")
         def draft_review() -> str:
             return render("draft-review.html")
+
+    ``meta`` is out-of-band data for the resource, carried through untouched.
+    For a document a host renders, this is where ``ui.csp``, ``ui.permissions``
+    and ``ui.prefersBorder`` go. Registration puts it on the read response as
+    well as on the listing entry, because a host reads the rendering contract
+    from the read.
 
     The docstring is the description unless one is given. A declaration a
     tool passes as its ``ui`` is registered with that tool, on every path a
@@ -332,6 +343,7 @@ def resource(
             title=title,
             description=description or inspect.getdoc(func),
             mime_type=mime_type,
+            meta=meta,
             file=_beside(func, file) if file is not None else None,
             func=func,
         )
@@ -381,15 +393,27 @@ class ResourceRegistry:
         """Every registered resource, in URI order."""
         return (self._resources[uri] for uri in self._uris)
 
-    def add(self, resource: Resource, contents: str | bytes) -> RegisteredResource:
-        """Register a resource at its own URI, replacing any resource already there."""
-        return self._store(resource, contents, declaration=None)
+    def add(
+        self,
+        resource: Resource,
+        contents: str | bytes,
+        contents_meta: dict[str, Any] | None = None,
+    ) -> RegisteredResource:
+        """Register a resource at its own URI, replacing any resource already there.
+
+        ``contents_meta`` fills the read response's own ``_meta``, which is a
+        different slot from the listing entry's ``resource.meta`` and is where a
+        host reads a document's rendering contract. This level fills exactly the
+        slot it is given.
+        """
+        return self._store(resource, contents, declaration=None, contents_meta=contents_meta)
 
     def _store(
         self,
         resource: Resource,
         contents: str | bytes,
         declaration: ResourceDeclaration | None,
+        contents_meta: dict[str, Any] | None = None,
     ) -> RegisteredResource:
         """Hold the resource and its resolved body at the resource's URI.
 
@@ -418,12 +442,14 @@ class ResourceRegistry:
                 uri=resource.uri,
                 mimeType=resource.mimeType,
                 blob=base64.b64encode(contents).decode("ascii"),
+                _meta=contents_meta,
             )
         else:
             body = TextResourceContents(
                 uri=resource.uri,
                 mimeType=resource.mimeType,
                 text=contents,
+                _meta=contents_meta,
             )
 
         registered = RegisteredResource(resource=resource, contents=body, declaration=declaration)
@@ -489,8 +515,14 @@ class ResourceRegistry:
             title=declaration.title,
             description=declaration.description,
             mimeType=mime_type,
+            _meta=declaration.meta,
         )
-        return self._store(resource, _contents(declaration, mime_type), declaration=declaration)
+        return self._store(
+            resource,
+            _contents(declaration, mime_type),
+            declaration=declaration,
+            contents_meta=declaration.meta,
+        )
 
     def get(self, uri: str) -> RegisteredResource:
         try:

--- a/libs/arcade-core/arcade_core/resources.py
+++ b/libs/arcade-core/arcade_core/resources.py
@@ -167,8 +167,9 @@ class ResourceDeclaration:
     func: Callable[[], Any] | None = field(default=None, compare=False, repr=False)
     #: Out-of-band data for the resource, carried through untouched. A host reads a
     #: document's rendering contract from the read response, so registration puts
-    #: this on the contents as well as on the listing entry.
-    meta: dict[str, Any] | None = None
+    #: this on the contents as well as on the listing entry. Out of the comparison
+    #: because a dict is unhashable and this class is frozen.
+    meta: dict[str, Any] | None = field(default=None, compare=False)
 
     def __call__(self) -> Any:
         """Run the declaring function, so a toolkit's own tests can call it directly."""
@@ -393,20 +394,14 @@ class ResourceRegistry:
         """Every registered resource, in URI order."""
         return (self._resources[uri] for uri in self._uris)
 
-    def add(
-        self,
-        resource: Resource,
-        contents: str | bytes,
-        contents_meta: dict[str, Any] | None = None,
-    ) -> RegisteredResource:
+    def add(self, resource: Resource, contents: str | bytes) -> RegisteredResource:
         """Register a resource at its own URI, replacing any resource already there.
 
-        ``contents_meta`` fills the read response's own ``_meta``, which is a
-        different slot from the listing entry's ``resource.meta`` and is where a
-        host reads a document's rendering contract. This level fills exactly the
-        slot it is given.
+        A resource's own ``_meta`` reaches the read response through ``declare``,
+        which fills both slots from one declared value. Setting only the read
+        slot would be a state no other transport can represent.
         """
-        return self._store(resource, contents, declaration=None, contents_meta=contents_meta)
+        return self._store(resource, contents, declaration=None)
 
     def _store(
         self,

--- a/libs/arcade-core/pyproject.toml
+++ b/libs/arcade-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-core"
-version = "4.17.0"
+version = "4.18.0"
 description = "Arcade Core - Core library for Arcade platform"
 readme = "README.md"
 license = { text = "MIT" }

--- a/libs/arcade-mcp-server/arcade_mcp_server/managers/resource.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/managers/resource.py
@@ -191,11 +191,13 @@ class ResourceManager(ComponentManager[str, Resource]):
             return self._coerce_result(uri, template.mimeType, result, template.meta)
 
         try:
-            _ = await self.registry.get(uri)
+            placeholder = await self.registry.get(uri)
         except KeyError as _e:
             raise NotFoundError(f"Resource '{uri}' not found")
 
-        return [TextResourceContents(uri=uri, text="")]  # static placeholder
+        # Registered with no handler, so there is no body to serve. The rendering
+        # contract still belongs to the resource and still travels.
+        return [TextResourceContents(uri=uri, text="", _meta=placeholder.meta)]
 
     @staticmethod
     def _coerce_result(

--- a/libs/arcade-mcp-server/arcade_mcp_server/managers/resource.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/managers/resource.py
@@ -146,18 +146,20 @@ class ResourceManager(ComponentManager[str, Resource]):
     async def read_resource(self, uri: str) -> list[ResourceContents]:
         handler = self._resource_handlers.get(uri)
         if handler:
-            # Look up the registered resource's mimeType so we can propagate it
+            # A host reads a document's rendering contract off this response, so
+            # the registered resource's own _meta travels with its mime type.
             mime_type: str | None = None
+            meta: dict[str, Any] | None = None
             try:
                 registered: Resource = await self.registry.get(uri)
-                mime_type = registered.mimeType
+                mime_type, meta = registered.mimeType, registered.meta
             except KeyError:
                 pass
 
             result = handler(uri)
             if hasattr(result, "__await__"):
                 result = await result
-            return self._coerce_result(uri, mime_type, result)
+            return self._coerce_result(uri, mime_type, result, meta)
 
         # Try template matching before giving up — collect all matches
         matches: list[tuple[str, re.Match[str]]] = []
@@ -182,11 +184,11 @@ class ResourceManager(ComponentManager[str, Resource]):
             tmpl_str, match = matches[0]
             params = match.groupdict()
             tmpl_handler = self._template_handlers[tmpl_str]
-            mime_type = self._templates[tmpl_str].mimeType
+            template = self._templates[tmpl_str]
             result = tmpl_handler(uri, **params)
             if hasattr(result, "__await__"):
                 result = await result
-            return self._coerce_result(uri, mime_type, result)
+            return self._coerce_result(uri, template.mimeType, result, template.meta)
 
         try:
             _ = await self.registry.get(uri)
@@ -196,23 +198,40 @@ class ResourceManager(ComponentManager[str, Resource]):
         return [TextResourceContents(uri=uri, text="")]  # static placeholder
 
     @staticmethod
-    def _coerce_result(uri: str, mime_type: str | None, result: Any) -> list[ResourceContents]:
-        """Convert a handler return value into a list of ResourceContents."""
+    def _coerce_result(
+        uri: str,
+        mime_type: str | None,
+        result: Any,
+        meta: dict[str, Any] | None = None,
+    ) -> list[ResourceContents]:
+        """Convert a handler return value into a list of ResourceContents.
+
+        A handler that builds its own contents objects owns their ``_meta`` and is
+        left alone; everything else is given the registered resource's.
+        """
         if isinstance(result, bytes):
             blob = base64.b64encode(result).decode("ascii")
-            return [BlobResourceContents(uri=uri, mimeType=mime_type, blob=blob)]
+            return [BlobResourceContents(uri=uri, mimeType=mime_type, blob=blob, _meta=meta)]
         elif isinstance(result, str):
-            return [TextResourceContents(uri=uri, mimeType=mime_type, text=result)]
+            return [TextResourceContents(uri=uri, mimeType=mime_type, text=result, _meta=meta)]
         elif isinstance(result, dict):
             if "text" in result:
-                return [TextResourceContents(uri=uri, mimeType=mime_type, text=result["text"])]
+                return [
+                    TextResourceContents(
+                        uri=uri, mimeType=mime_type, text=result["text"], _meta=meta
+                    )
+                ]
             if "blob" in result:
-                return [BlobResourceContents(uri=uri, mimeType=mime_type, blob=result["blob"])]
-            return [ResourceContents(uri=uri, mimeType=mime_type)]
+                return [
+                    BlobResourceContents(
+                        uri=uri, mimeType=mime_type, blob=result["blob"], _meta=meta
+                    )
+                ]
+            return [ResourceContents(uri=uri, mimeType=mime_type, _meta=meta)]
         elif isinstance(result, list):
             return result
         else:
-            return [TextResourceContents(uri=uri, mimeType=mime_type, text=str(result))]
+            return [TextResourceContents(uri=uri, mimeType=mime_type, text=str(result), _meta=meta)]
 
     async def add_resource(
         self, resource: Resource, handler: Callable[[str], Any] | None = None

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arcade-core>=4.18.0,<5.0.0",
     "arcade-serve>=3.6.0,<4.0.0",
-    "arcade-tdk>=3.12.0,<4.0.0",
+    "arcade-tdk>=3.13.0,<4.0.0",
     "arcadepy>=1.5.0",
     "pydantic>=2.0.0",
     "fastapi>=0.100.0",

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.29.0"
+version = "1.30.0"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "arcade-core>=4.17.0,<5.0.0",
+    "arcade-core>=4.18.0,<5.0.0",
     "arcade-serve>=3.6.0,<4.0.0",
     "arcade-tdk>=3.12.0,<4.0.0",
     "arcadepy>=1.5.0",

--- a/libs/arcade-tdk/pyproject.toml
+++ b/libs/arcade-tdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arcade-tdk"
-version = "3.12.0"
+version = "3.13.0"
 description = "Arcade TDK - Toolkit Development Kit for building Arcade tools"
 readme = "README.md"
 license = { text = "MIT" }
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
-dependencies = ["arcade-core>=4.17.0,<5.0.0", "pydantic>=2.7.0"]
+dependencies = ["arcade-core>=4.18.0,<5.0.0", "pydantic>=2.7.0"]
 
 [project.optional-dependencies]
 dev = [

--- a/libs/tests/arcade_mcp_server/test_resource.py
+++ b/libs/tests/arcade_mcp_server/test_resource.py
@@ -12,6 +12,7 @@ from arcade_mcp_server.managers.resource import (
     _is_template_uri,
     _template_to_regex,
     _template_to_sample_uri,
+    make_static_handler,
 )
 from arcade_mcp_server.types import (
     BlobResourceContents,
@@ -759,3 +760,87 @@ async def test_load_from_catalog_serves_a_declared_blob():
     assert isinstance(contents[0], BlobResourceContents)
     assert base64.b64decode(contents[0].blob) == b"\x89PNG\r\n"
     assert contents[0].mimeType == "image/png"
+
+
+UI_META = {"ui": {"permissions": {"clipboardWrite": {}}, "prefersBorder": False}}
+
+
+@pytest.mark.asyncio
+async def test_a_registered_resources_meta_reaches_the_read():
+    """A host reads a document's rendering contract off this response."""
+    manager = ResourceManager()
+    await manager.start()
+    await manager.add_resource(
+        Resource(
+            uri="ui://Kit/1.0.0/panel.html",
+            name="panel",
+            mimeType="text/html;profile=mcp-app",
+            _meta=UI_META,
+        ),
+        handler=make_static_handler("<!DOCTYPE html><p>panel</p>"),
+    )
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/panel.html")
+
+    assert contents[0].meta == UI_META
+
+
+@pytest.mark.asyncio
+async def test_load_from_catalog_keeps_a_declarations_meta():
+    from arcade_core.catalog import ToolCatalog
+    from arcade_core.resources import ResourceDeclaration
+
+    catalog = ToolCatalog()
+    catalog.resources.declare(
+        ResourceDeclaration(
+            path="panel.html",
+            name="panel",
+            mime_type="text/html;profile=example",
+            meta=UI_META,
+            func=lambda: "<!DOCTYPE html><p>panel</p>",
+        ),
+        toolkit_name="Kit",
+        toolkit_version="1.0.0",
+    )
+    manager = ResourceManager()
+    await manager.start()
+
+    await manager.load_from_catalog(catalog)
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/panel.html")
+    assert contents[0].meta == UI_META
+
+
+@pytest.mark.asyncio
+async def test_a_handler_that_builds_its_own_contents_keeps_their_meta():
+    """Such a handler owns the whole object, so nothing is overwritten for it."""
+    handler_meta = {"ui": {"domain": "handler.example.com"}}
+    manager = ResourceManager()
+    await manager.start()
+    await manager.add_resource(
+        Resource(uri="ui://Kit/1.0.0/own.html", name="own", mimeType="text/html", _meta=UI_META),
+        handler=lambda uri: [
+            TextResourceContents(
+                uri=uri, mimeType="text/html", text="<p>own</p>", _meta=handler_meta
+            )
+        ],
+    )
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/own.html")
+
+    assert contents[0].meta == handler_meta
+
+
+@pytest.mark.asyncio
+async def test_a_resource_without_meta_still_reads_clean():
+    manager = ResourceManager()
+    await manager.start()
+    await manager.add_resource(
+        Resource(uri="ui://Kit/1.0.0/plain.html", name="plain", mimeType="text/html"),
+        handler=make_static_handler("<p>plain</p>"),
+    )
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/plain.html")
+
+    assert contents[0].meta is None
+    assert "_meta" not in contents[0].model_dump(by_alias=True, exclude_none=True)

--- a/libs/tests/arcade_mcp_server/test_resource.py
+++ b/libs/tests/arcade_mcp_server/test_resource.py
@@ -832,6 +832,39 @@ async def test_a_handler_that_builds_its_own_contents_keeps_their_meta():
 
 
 @pytest.mark.asyncio
+async def test_the_read_puts_meta_on_the_wire_under_the_underscore_key():
+    """A client looks for ``_meta``; a Python-side ``meta`` would be a different field."""
+    manager = ResourceManager()
+    await manager.start()
+    await manager.add_resource(
+        Resource(uri="ui://Kit/1.0.0/wire.html", name="wire", mimeType="text/html", _meta=UI_META),
+        handler=make_static_handler("<p>wire</p>"),
+    )
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/wire.html")
+    dumped = contents[0].model_dump(by_alias=True, exclude_none=True)
+
+    assert dumped["_meta"] == UI_META
+    assert "meta" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_a_handler_less_resource_still_carries_its_meta():
+    """There is no body to serve, and the rendering contract still belongs to it."""
+    manager = ResourceManager()
+    await manager.start()
+    await manager.add_resource(
+        Resource(uri="ui://Kit/1.0.0/none.html", name="none", mimeType="text/html", _meta=UI_META),
+        handler=None,
+    )
+
+    contents = await manager.read_resource("ui://Kit/1.0.0/none.html")
+
+    assert contents[0].meta == UI_META
+    assert contents[0].text == ""
+
+
+@pytest.mark.asyncio
 async def test_a_resource_without_meta_still_reads_clean():
     manager = ResourceManager()
     await manager.start()

--- a/libs/tests/core/test_resource_meta.py
+++ b/libs/tests/core/test_resource_meta.py
@@ -75,24 +75,32 @@ def test_the_object_is_carried_verbatim():
     assert registered.resource.meta == later
 
 
-def test_add_fills_exactly_the_slot_it_is_given():
-    """The low-level path fills one slot at a time; fanning out belongs to declare."""
+def test_a_listing_meta_handed_to_add_does_not_leak_onto_the_contents():
+    """The two are different slots, so nothing is copied between them.
+
+    ``declare`` is the only thing that fills both, and it does so from one
+    declared value rather than by copying one slot into the other.
+    """
     registry = ResourceRegistry()
 
-    listing_only = registry.add(
+    registered = registry.add(
         Resource(uri="ui://Kit/1.0.0/a.html", name="a", mimeType="text/html", _meta=UI_META),
         "<p>a</p>",
     )
-    assert listing_only.resource.meta == UI_META
-    assert listing_only.contents.meta is None, "a listing _meta must not leak onto the contents"
 
-    contents_only = registry.add(
-        Resource(uri="ui://Kit/1.0.0/b.html", name="b", mimeType="text/html"),
-        "<p>b</p>",
-        contents_meta=UI_META,
-    )
-    assert contents_only.contents.meta == UI_META
-    assert contents_only.resource.meta is None, "a contents _meta must not leak onto the listing"
+    assert registered.resource.meta == UI_META
+    assert registered.contents.meta is None
+
+
+def test_a_declaration_stays_hashable_when_it_carries_meta():
+    """The class is frozen, so a compared dict field would make it unhashable."""
+
+    @resource(path="panel.html", meta=UI_META)
+    def panel() -> str:
+        return "x"
+
+    assert hash(panel) == hash(panel)
+    assert panel in {panel}
 
 
 @pytest.mark.parametrize("body", ["<p>text</p>", b"\x00\x01"])

--- a/libs/tests/core/test_resource_meta.py
+++ b/libs/tests/core/test_resource_meta.py
@@ -1,0 +1,123 @@
+"""A resource's own ``_meta`` reaches both slots a client can read it from.
+
+A host renders a document by reading the rendering contract off the read
+response's contents, so the read is the slot that decides whether an interface
+works. The listing carries it too, from the same authored value, so the two
+cannot disagree about what a document asked for.
+"""
+
+import pytest
+from arcade_core.resource_schema import BlobResourceContents, Resource, TextResourceContents
+from arcade_core.resources import ResourceDeclaration, ResourceRegistry, resource
+
+UI_META = {
+    "ui": {
+        "csp": {"connectDomains": ["https://api.example.com"]},
+        "permissions": {"clipboardWrite": {}},
+        "prefersBorder": False,
+    }
+}
+
+
+def _registry_with(declaration):
+    registry = ResourceRegistry()
+    return registry, registry.declare(declaration, toolkit_name="Kit", toolkit_version="1.0.0")
+
+
+def test_a_declared_meta_reaches_the_listing_and_the_read():
+    @resource(path="panel.html", meta=UI_META)
+    def panel() -> str:
+        return "<!DOCTYPE html><p>panel</p>"
+
+    _, registered = _registry_with(panel)
+
+    assert registered.resource.meta == UI_META
+    assert registered.contents.meta == UI_META
+
+
+def test_a_blob_carries_it_too():
+    @resource(path="icon.png", mime_type="image/png", meta=UI_META)
+    def icon() -> bytes:
+        return b"\x89PNG\r\n"
+
+    _, registered = _registry_with(icon)
+
+    assert isinstance(registered.contents, BlobResourceContents)
+    assert registered.contents.meta == UI_META
+
+
+def test_no_declared_meta_leaves_both_slots_absent():
+    """Absent rather than an empty object, so the wire stays clean under exclude_none."""
+
+    @resource(path="panel.html")
+    def panel() -> str:
+        return "<!DOCTYPE html><p>panel</p>"
+
+    _, registered = _registry_with(panel)
+
+    assert registered.resource.meta is None
+    assert registered.contents.meta is None
+    assert "_meta" not in registered.contents.model_dump(by_alias=True, exclude_none=True)
+    assert "_meta" not in registered.resource.model_dump(by_alias=True, exclude_none=True)
+
+
+def test_the_object_is_carried_verbatim():
+    """The extension ships on its own schedule, so an unknown key must survive."""
+    later = {"ui": {"somethingAddedLater": {"nested": [1, 2]}}}
+
+    @resource(path="panel.html", meta=later)
+    def panel() -> str:
+        return "x"
+
+    _, registered = _registry_with(panel)
+
+    assert registered.contents.meta == later
+    assert registered.resource.meta == later
+
+
+def test_add_fills_exactly_the_slot_it_is_given():
+    """The low-level path fills one slot at a time; fanning out belongs to declare."""
+    registry = ResourceRegistry()
+
+    listing_only = registry.add(
+        Resource(uri="ui://Kit/1.0.0/a.html", name="a", mimeType="text/html", _meta=UI_META),
+        "<p>a</p>",
+    )
+    assert listing_only.resource.meta == UI_META
+    assert listing_only.contents.meta is None, "a listing _meta must not leak onto the contents"
+
+    contents_only = registry.add(
+        Resource(uri="ui://Kit/1.0.0/b.html", name="b", mimeType="text/html"),
+        "<p>b</p>",
+        contents_meta=UI_META,
+    )
+    assert contents_only.contents.meta == UI_META
+    assert contents_only.resource.meta is None, "a contents _meta must not leak onto the listing"
+
+
+@pytest.mark.parametrize("body", ["<p>text</p>", b"\x00\x01"])
+def test_a_hand_built_declaration_carries_it(body):
+    """The dataclass is public, so the field has to work without the decorator."""
+    registry = ResourceRegistry()
+    mime = "text/html" if isinstance(body, str) else "application/octet-stream"
+
+    registered = registry.declare(
+        ResourceDeclaration(
+            path="hand.bin", name="hand", mime_type=mime, meta=UI_META, func=lambda: body
+        ),
+        toolkit_name="Kit",
+        toolkit_version="1.0.0",
+    )
+
+    assert registered.contents.meta == UI_META
+
+
+def test_a_text_document_keeps_its_body_alongside_the_meta():
+    @resource(path="panel.html", meta=UI_META)
+    def panel() -> str:
+        return "<!DOCTYPE html><p>panel</p>"
+
+    _, registered = _registry_with(panel)
+
+    assert isinstance(registered.contents, TextResourceContents)
+    assert registered.contents.text == "<!DOCTYPE html><p>panel</p>"

--- a/libs/tests/worker/test_worker_resources_endpoints.py
+++ b/libs/tests/worker/test_worker_resources_endpoints.py
@@ -47,6 +47,22 @@ def serving():
 
 
 @pytest.fixture
+def serving_with_meta():
+    """A worker whose document declares its own rendering contract."""
+    app = FastAPI()
+    worker = FastAPIWorker(app=app, disable_auth=True)
+    worker.register_tool(sample_tool, toolkit_name="fixture_kit")
+    worker.catalog.resources.add(
+        Resource(uri=DRAFT_URI, name="Draft review", mimeType=UI_MIME),
+        DRAFT_BODY,
+        contents_meta={"ui": {"prefersBorder": False}},
+    )
+    registered = worker.catalog.resources.get(DRAFT_URI)
+    registered.resource.meta = {"ui": {"prefersBorder": False}}
+    return TestClient(app)
+
+
+@pytest.fixture
 def empty():
     """A worker on this release that simply has no resources to serve."""
     app = FastAPI()
@@ -83,6 +99,24 @@ def test_read_returns_a_result_object(serving):
     assert response.json() == {
         "contents": [{"uri": DRAFT_URI, "mimeType": UI_MIME, "text": DRAFT_BODY}]
     }
+
+
+def test_the_read_carries_a_resources_own_meta(serving_with_meta):
+    """A host reads a document's rendering contract off this response.
+
+    Asserted on the wire under the underscore key, because a host looks for
+    ``_meta`` and a Python-side ``meta`` would parse as a different field.
+    """
+    body = serving_with_meta.post("/worker/resources/read", json={"uri": DRAFT_URI}).text
+
+    assert '"_meta":{"ui":{"prefersBorder":false}}' in body
+    assert '"meta"' not in body.replace('"_meta"', "")
+
+
+def test_the_listing_carries_it_too(serving_with_meta):
+    listed = serving_with_meta.post("/worker/resources/list", json={}).json()
+
+    assert listed["resources"][0]["_meta"] == {"ui": {"prefersBorder": False}}
 
 
 def test_absent_optional_fields_are_omitted_rather_than_null(serving):

--- a/libs/tests/worker/test_worker_resources_endpoints.py
+++ b/libs/tests/worker/test_worker_resources_endpoints.py
@@ -12,6 +12,7 @@ from typing import Annotated
 
 import pytest
 from arcade_core.resource_schema import Resource
+from arcade_core.resources import ResourceDeclaration
 from arcade_serve.fastapi.worker import FastAPIWorker
 from arcade_tdk import ToolContext, tool
 from fastapi import FastAPI
@@ -52,13 +53,17 @@ def serving_with_meta():
     app = FastAPI()
     worker = FastAPIWorker(app=app, disable_auth=True)
     worker.register_tool(sample_tool, toolkit_name="fixture_kit")
-    worker.catalog.resources.add(
-        Resource(uri=DRAFT_URI, name="Draft review", mimeType=UI_MIME),
-        DRAFT_BODY,
-        contents_meta={"ui": {"prefersBorder": False}},
+    worker.catalog.resources.declare(
+        ResourceDeclaration(
+            path="draft-review.html",
+            name="Draft review",
+            mime_type=UI_MIME,
+            meta={"ui": {"prefersBorder": False}},
+            func=lambda: DRAFT_BODY,
+        ),
+        toolkit_name="Gmail",
+        toolkit_version="8.1.0",
     )
-    registered = worker.catalog.resources.get(DRAFT_URI)
-    registered.resource.meta = {"ui": {"prefersBorder": False}}
     return TestClient(app)
 
 
@@ -107,10 +112,10 @@ def test_the_read_carries_a_resources_own_meta(serving_with_meta):
     Asserted on the wire under the underscore key, because a host looks for
     ``_meta`` and a Python-side ``meta`` would parse as a different field.
     """
-    body = serving_with_meta.post("/worker/resources/read", json={"uri": DRAFT_URI}).text
+    response = serving_with_meta.post("/worker/resources/read", json={"uri": DRAFT_URI})
 
-    assert '"_meta":{"ui":{"prefersBorder":false}}' in body
-    assert '"meta"' not in body.replace('"_meta"', "")
+    assert response.json()["contents"][0]["_meta"] == {"ui": {"prefersBorder": False}}
+    assert '"meta"' not in response.text.replace('"_meta"', ""), "the alias must be on the wire"
 
 
 def test_the_listing_carries_it_too(serving_with_meta):


### PR DESCRIPTION
Resolves [TOO-1943](https://linear.app/arcadedev/issue/TOO-1943).
Resolves [TOO-1944](https://linear.app/arcadedev/issue/TOO-1944).

## Before

As a tooling author, I ship an interface that has to reach an external origin, or that should not be wrapped in the host's own bordered card. The extension puts all of that on the resource's `_meta.ui`: `csp` allowlists naming which origins my scripts, styles and network calls may come from, `permissions` for things like clipboard access, `domain`, and `prefersBorder`. I declare my document with `@resource` and there is nowhere to put any of it, so my interface renders and then has every outbound call refused by the host's default-deny policy, and gets a card drawn around it whether it wants one or not.

If I am writing a standalone server instead, `MCPApp.add_resource(meta=...)` looks like the channel. It is not: it fills the listing entry, and a host reads the rendering contract off the read response. A host may skip the listing for UI resources entirely.

## After

As a tooling author, I write `@resource(file="calculator.html", meta={"ui": {"csp": {...}, "prefersBorder": False}})`. The object is carried through untouched, and registration puts it on both the listing entry and the read response from that one value, so the two cannot disagree about what my document asked for. A host reads it where the extension says to look, my calls reach the origins I declared, and my card is mine to draw or not.

`MCPApp.add_resource(meta=...)` keeps its name and its meaning and now reaches the read response too, so a standalone server that was already setting it starts working without changing a line.

## Why the read response is the one that matters

The extension defines the contract on the `resources/read` contents item, requires a host to fetch a tool's interface with a read, and allows a server to omit UI resources from `resources/list` altogether. A document whose `_meta.ui` rides only on the listing therefore reaches a host that never asked for the listing with nothing at all.

## Three paths built a read body, and all three dropped it

`ResourceRegistry._store` for the worker protocol, `ResourceManager._coerce_result` for the standalone endpoint, and `ResourceManager.load_from_catalog` for a toolkit's declarations served on that endpoint. All three now carry it. A handler that builds its own contents objects owns their `_meta` and is left alone.

Verified end to end through the engine's real HTTP client against a live local worker: a tool carries `_meta.ui.resourceUri`, the read at that URI returns the document with `text/html;profile=mcp-app` byte-identical, and the resource's own `_meta.ui` arrives with `csp`, `permissions` and `prefersBorder` intact. The engine needed no change; its resource DTOs are the official Go SDK types and those already carry `_meta`. Coverage for that side is in ArcadeAI/monorepo#3984.

## One authored value, one slot-filler

`declare` is the only thing that fills both slots, from the value an author declared. The registry's low-level `add` fills the listing only, so a resource can never end up with a read slot that disagrees with its listing, which is a state the standalone server has no way to represent.

Releases arcade-core 4.18.0, arcade-tdk 3.13.0 and arcade-mcp-server 1.30.0. arcade-tdk's floor moves with arcade-core because it re-exports `resource()`, as it has in every release that changed `arcade_core.resources`.

~ 🐙 Eriq, Eric's Agent

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches resource list/read payloads used by hosts for UI sandboxing; behavior change is additive but incorrect propagation could break CSP or permissions enforcement.
> 
> **Overview**
> Tooling authors can attach **out-of-band rendering metadata** (e.g. `ui.csp`, `ui.permissions`, `ui.prefersBorder`) when declaring static UI documents via **`@resource(..., meta=...)`**. Registration copies that dict **verbatim** onto both the **resources/list** entry and the **resources/read** contents item, so hosts that only read never miss the contract.
> 
> **arcade-core** adds `meta` on `ResourceDeclaration` and threads it through `ResourceRegistry.declare` into stored `Resource` and `TextResourceContents` / `BlobResourceContents` (`contents_meta` on `_store`). **`registry.add`** still sets listing `_meta` only—not read contents—matching the intended split.
> 
> **arcade-mcp-server** extends `ResourceManager.read_resource` and `_coerce_result` so registered or template `_meta` is applied when handlers return primitives; handlers that return their own `ResourceContents` lists are unchanged. Handler-less resources still return empty text with `_meta` attached.
> 
> Bumps **arcade-core 4.18.0**, **arcade-mcp-server 1.30.0**, **arcade-tdk 3.13.0**, with tests across core registry, MCP manager, and worker HTTP endpoints (wire `_meta` alias).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f491df2b5b6861cd4f7a75e721f5884258caba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

