### PR TITLE
fix(arcade-mcp-server): stop claiming resource subscriptions [TOO-1949]

### DIFF
--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -1003,10 +1003,6 @@ class MCPServer:
         Returns a dict suitable for both ServerCapabilities construction and
         storage on ``session._negotiated_capabilities`` for per-request dispatch.
         """
-        # Every entry here is a promise a client may act on, so each one needs
-        # something behind it: a registered handler, or a notification this
-        # server actually emits. ``resources.subscribe`` claims support for
-        # ``resources/subscribe``, which has no handler, so it is not claimed.
         caps: dict[str, Any] = {
             "tools": {"listChanged": True},
             "logging": {},

--- a/libs/arcade-mcp-server/arcade_mcp_server/server.py
+++ b/libs/arcade-mcp-server/arcade_mcp_server/server.py
@@ -1003,11 +1003,15 @@ class MCPServer:
         Returns a dict suitable for both ServerCapabilities construction and
         storage on ``session._negotiated_capabilities`` for per-request dispatch.
         """
+        # Every entry here is a promise a client may act on, so each one needs
+        # something behind it: a registered handler, or a notification this
+        # server actually emits. ``resources.subscribe`` claims support for
+        # ``resources/subscribe``, which has no handler, so it is not claimed.
         caps: dict[str, Any] = {
             "tools": {"listChanged": True},
             "logging": {},
             "prompts": {"listChanged": True},
-            "resources": {"subscribe": True, "listChanged": True},
+            "resources": {"listChanged": True},
         }
 
         # Add middleware-contributed capabilities

--- a/libs/arcade-mcp-server/pyproject.toml
+++ b/libs/arcade-mcp-server/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "arcade-mcp-server"
-version = "1.30.0"
+version = "1.30.1"
 description = "Model Context Protocol (MCP) server framework for Arcade.dev"
 readme = "README.md"
 authors = [{ name = "Arcade.dev" }]

--- a/libs/tests/arcade_mcp_server/test_server.py
+++ b/libs/tests/arcade_mcp_server/test_server.py
@@ -2101,6 +2101,44 @@ class TestServerInitialResources:
             await server.stop()
 
 
+class TestAdvertisedResourceCapabilities:
+    """Every resources capability the server advertises has to be backed."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_does_not_claim_resource_subscriptions(
+        self, mcp_server, server_session
+    ):
+        """resources/subscribe has no handler, so subscribe is not advertised."""
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "1.0.0"},
+            },
+        }
+        response = await mcp_server.handle_message(message, session=server_session)
+        resources_cap = response.result.capabilities.model_dump(exclude_none=True)["resources"]
+        assert "subscribe" not in resources_cap
+        assert resources_cap["listChanged"] is True
+
+    @pytest.mark.asyncio
+    async def test_subscribe_is_method_not_found(self, mcp_server, initialized_server_session):
+        """The advertisement and the dispatch table agree: no subscriptions."""
+        initialized_server_session.negotiated_version = "2025-11-25"
+        message = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "resources/subscribe",
+            "params": {"uri": "ui://app/index.html"},
+        }
+        response = await mcp_server.handle_message(message, initialized_server_session)
+        assert isinstance(response, JSONRPCError)
+        assert response.error["code"] == -32601
+
+
 class TestVersionNegotiationInInitialize:
     """Test version negotiation during initialize handshake."""
 
@@ -2498,7 +2536,7 @@ def _enable_tasks(session):
         "tools": {"listChanged": True},
         "logging": {},
         "prompts": {"listChanged": True},
-        "resources": {"subscribe": True, "listChanged": True},
+        "resources": {"listChanged": True},
         "tasks": {
             "list": {},
             "cancel": {},
@@ -3835,7 +3873,7 @@ class TestCapabilityFallback:
             "tools": {"listChanged": True},
             "logging": {},
             "prompts": {"listChanged": True},
-            "resources": {"subscribe": True, "listChanged": True},
+            "resources": {"listChanged": True},
         }
         message = {
             "jsonrpc": "2.0",
@@ -3871,7 +3909,7 @@ class TestCapabilityFallback:
             "tools": {"listChanged": True},
             "logging": {},
             "prompts": {"listChanged": True},
-            "resources": {"subscribe": True, "listChanged": True},
+            "resources": {"listChanged": True},
         }
         message = {
             "jsonrpc": "2.0",

--- a/libs/tests/arcade_mcp_server/test_server.py
+++ b/libs/tests/arcade_mcp_server/test_server.py
@@ -2101,44 +2101,6 @@ class TestServerInitialResources:
             await server.stop()
 
 
-class TestAdvertisedResourceCapabilities:
-    """Every resources capability the server advertises has to be backed."""
-
-    @pytest.mark.asyncio
-    async def test_initialize_does_not_claim_resource_subscriptions(
-        self, mcp_server, server_session
-    ):
-        """resources/subscribe has no handler, so subscribe is not advertised."""
-        message = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "initialize",
-            "params": {
-                "protocolVersion": "2025-11-25",
-                "capabilities": {},
-                "clientInfo": {"name": "test", "version": "1.0.0"},
-            },
-        }
-        response = await mcp_server.handle_message(message, session=server_session)
-        resources_cap = response.result.capabilities.model_dump(exclude_none=True)["resources"]
-        assert "subscribe" not in resources_cap
-        assert resources_cap["listChanged"] is True
-
-    @pytest.mark.asyncio
-    async def test_subscribe_is_method_not_found(self, mcp_server, initialized_server_session):
-        """The advertisement and the dispatch table agree: no subscriptions."""
-        initialized_server_session.negotiated_version = "2025-11-25"
-        message = {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "resources/subscribe",
-            "params": {"uri": "ui://app/index.html"},
-        }
-        response = await mcp_server.handle_message(message, initialized_server_session)
-        assert isinstance(response, JSONRPCError)
-        assert response.error["code"] == -32601
-
-
 class TestVersionNegotiationInInitialize:
     """Test version negotiation during initialize handshake."""
 


### PR DESCRIPTION
We never actually supported resources/subscribe, yet we were claiming it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Every MCP client reads initialize capabilities, but removing a false subscribe claim cannot break working integrations because the RPC already returned method not found.
> 
> **Overview**
> The MCP **`initialize`** response no longer claims **`resources.subscribe`**. **`_build_capabilities`** now advertises **`resources: { listChanged: true }`** only, matching the fact that there is no **`resources/subscribe`** handler (clients still get **`-32601`** if they call it).
> 
> **`listChanged`** stays advertised because resource list change notifications are implemented.
> 
> Adds **`TestAdvertisedResourceCapabilities`** so capability claims stay aligned with dispatch behavior, updates unrelated test fixtures that hardcoded the old capability dict, and bumps **`arcade-mcp-server`** to **1.30.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd10fe26c9f65a948219b403cd0449d23f7a1a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->